### PR TITLE
feat: Api to create orgs + script to generate orgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ package-lock.json
 yarn.lock
 .eslintcache
 local.*
+test/research

--- a/src/lib/group/index.ts
+++ b/src/lib/group/index.ts
@@ -1,0 +1,56 @@
+import 'source-map-support/register';
+import * as needle from 'needle';
+import * as debugLib from 'debug';
+import { getApiToken } from '../get-api-token';
+import { getSnykHost } from '../get-snyk-host';
+
+const debug = debugLib('snyk:api-group');
+
+export interface CreatedOrgResponse {
+  id: string;
+  name: string;
+  created: string;
+}
+export async function createOrg(
+  groupId: string,
+  name: string,
+  sourceOrgId?: string,
+): Promise<CreatedOrgResponse> {
+  const apiToken = getApiToken();
+  debug('Creating a new org:' + name);
+
+  if (!groupId || !name) {
+    throw new Error(
+      `Missing required parameters. Please ensure you have set: groupId, name.
+      \nFor more information see: https://snyk.docs.apiary.io/#reference/0/organizations-in-groups/create-a-new-organization-in-the-group`,
+    );
+  }
+  const body: {
+    name: string;
+    sourceOrgId?: string;
+  } = {
+    name,
+    sourceOrgId,
+  };
+  const SNYK_HOST = getSnykHost();
+
+  const res = await needle(
+    'post',
+    `${SNYK_HOST}/api/v1/group/${groupId}/org`,
+    body,
+    {
+      json: true,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      read_timeout: 30000,
+      headers: {
+        Authorization: `token ${apiToken}`,
+      },
+    },
+  );
+  if (res.statusCode && res.statusCode !== 200) {
+    throw new Error(
+      'Expected a 200 response, instead received: ' + JSON.stringify(res.body),
+    );
+  }
+  return res.body;
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './import';
 export * from './poll-import';
 export * from './project';
+export * from './group';

--- a/src/scripts/create-orgs.ts
+++ b/src/scripts/create-orgs.ts
@@ -1,0 +1,54 @@
+import * as debugLib from 'debug';
+import * as fs from 'fs';
+
+import { loadFile } from '../load-file';
+import { CreatedOrgResponse, createOrg } from '../lib';
+import { getLoggingPath } from '../lib/get-logging-path';
+
+const debug = debugLib('snyk:import-projects-script');
+
+interface CreateOrgData {
+  groupId: string;
+  name: string;
+  sourceOrgId?: string;
+}
+
+export async function logCreatedOrg(
+  origName: string,
+  orgData: CreatedOrgResponse,
+  loggingPath: string = getLoggingPath(),
+): Promise<void> {
+  try {
+    const { id, name, created } = orgData;
+    const log = `${origName},${name},${id},${created}\n`;
+    fs.appendFileSync(`${loggingPath}/created-orgs.csv`, log);
+  } catch (e) {
+    // do nothing
+  }
+}
+export async function CreateOrgs(
+  fileName: string,
+  loggingPath: string,
+): Promise<CreatedOrgResponse[]> {
+  const content = await loadFile(fileName);
+  const orgsData: CreateOrgData[] = [];
+  try {
+    orgsData.push(...JSON.parse(content).orgs);
+  } catch (e) {
+    throw new Error(`Failed to parse orgs from ${fileName}`);
+  }
+  debug(`Loaded ${orgsData.length} orgs to create ${Date.now()}`);
+  const createdOrgs: CreatedOrgResponse[] = [];
+  orgsData.forEach(async (orgData) => {
+    try {
+      const { groupId, name, sourceOrgId } = orgData;
+      const org = await createOrg(groupId, name, sourceOrgId);
+      createdOrgs.push(org);
+      logCreatedOrg(name, org, loggingPath);
+    } catch (e) {
+      debug(`Failed to create org with data: ${JSON.stringify(orgsData)}`);
+    }
+  });
+
+  return createdOrgs;
+}

--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -1,7 +1,10 @@
 import * as debugLib from 'debug';
 import * as path from 'path';
 import { loadFile } from '../load-file';
-import { importTargets, pollImportUrls } from '../lib';
+import {
+  importTargets,
+  pollImportUrls,
+} from '../lib';
 import { Project, ImportTarget } from '../lib/types';
 import { getLoggingPath } from '../lib/get-logging-path';
 import { getConcurrentImportsNumber } from '../lib/get-concurrent-imports-number';


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
- Create Org API
- Create orgs script that saves the results as a csv.
- no tests yet (can't delete the actual orgs via API so will need to mock the API requests)