### PR TITLE
fix: stick to 30s polling

### DIFF
--- a/src/lib/poll-import/index.ts
+++ b/src/lib/poll-import/index.ts
@@ -10,7 +10,7 @@ import { logFailedProjects } from '../../log-failed-projects';
 import { logFailedPollUrls } from '../../log-failed-polls';
 
 const debug = debugLib('snyk:poll-import');
-const MIN_RETRY_WAIT_TIME = 3000;
+const MIN_RETRY_WAIT_TIME = 30000;
 const MAX_RETRY_COUNT = 1000;
 
 export async function pollImportUrl(
@@ -43,13 +43,10 @@ export async function pollImportUrl(
       retryCount > 0
     ) {
       await sleep(retryWaitTime);
-      const increasedRetryWaitTime =
-        retryWaitTime + retryWaitTime * 0.1 * (MAX_RETRY_COUNT - retryCount);
-      debug(`Will re-check import task in "${increasedRetryWaitTime}ms"`);
+      debug(`Will re-check import task in "${retryWaitTime} ms"`);
       return await pollImportUrl(
         locationUrl,
         --retryCount,
-        increasedRetryWaitTime,
       );
     }
     const projects: Project[] = [];

--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -59,6 +59,8 @@ export async function ImportProjects(
   if (filteredTargets.length === 0) {
     return [];
   }
+  const skippedTargets = targets.length - filteredTargets.length;
+  debug(`Skipped previously imported ${skippedTargets}/${targets.length} targets`)
   for (
     let targetIndex = 0;
     targetIndex < filteredTargets.length;
@@ -68,8 +70,9 @@ export async function ImportProjects(
       targetIndex,
       targetIndex + concurrentTargets,
     );
+    const currentTargets = skippedTargets + targetIndex;
     debug(
-      `Importing batch ${targetIndex} - ${targetIndex +
+      `Importing batch ${currentTargets} - ${currentTargets +
         concurrentTargets} out of ${filteredTargets.length}`,
     );
     const pollingUrlsAndContext = await importTargets(batch, loggingPath);


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Reduce the polling time to always be 30s