### PR TITLE
feat: rename SNYK_API_TOKEN to SNYK_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Snyk API project importer
 
 ### Running the test locally
 You will need to set the following environment variable:
-  - `SNYK_API_TOKEN` - check 1 Password (search for "snyk-api-import")
+  - `SNYK_TOKEN_TEST` - snyk/orb (aka snyk/scan task in circle) uses `SNYK_TOKEN` and so does this lib, so overriding it in tests to avoid clash.
   - `SNYK_API='https://dev.snyk.io/api/v1'`
+  - `SNYK_TOKEN` - check 1 Password (search for "snyk-api-import")
 
 Run the tests with `npm test`
 
@@ -54,7 +55,7 @@ This script is intended to help import projects into Snyk with a controlled pace
   ```
 ### 2. Set the env vars mentioned:
   - `SNYK_IMPORT_PATH`- the path to the import file
-  - `SNYK_API_TOKEN` - your [Snyk api token](https://app.snyk.io/account)
+  - `SNYK_TOKEN` - your [Snyk api token](https://app.snyk.io/account)
   - `SNYK_LOG_PATH` - the path to folder where all logs should be saved
   - `CONCURRENT_IMPORTS` (optional) defaults to 5 repos at a time, which is the recommended amount to import at once as a max.  Just 1 repo may have many projects inside. (10 may also be okay if all repos are small)
   - `SNYK_API` (optional) defaults to `https://snyk.io/api/v1`

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write '{''{lib,test}/!(test/**/fixtures)/**/*,*}.{js,ts,json,yml}'",
     "lint": "npm run format:check && npm run lint:eslint",
     "lint:eslint": "eslint --cache '{lib,test}/**/*.ts'",
-    "test": "npm run lint && npm run build && npm run test:unit:debug",
+    "test": "npm run lint && npm run build && npm run test:unit",
     "test:unit": "jest",
     "test:unit:debug": "npm run build && DEBUG=* jest",
     "test:coverage": "npm run test:unit -- --coverage",

--- a/src/lib/get-api-token.ts
+++ b/src/lib/get-api-token.ts
@@ -1,9 +1,9 @@
 export function getApiToken(): string {
-  const apiToken = process.env.SNYK_API_TOKEN;
+  const apiToken = process.env.SNYK_TOKEN;
 
   if (!apiToken) {
     throw new Error(
-      `Please set the SNYK_API_TOKEN e.g. export SNYK_API_TOKEN='*****'`,
+      `Please set the SNYK_TOKEN e.g. export SNYK_TOKEN='*****'`,
     );
   }
   return apiToken;

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -18,6 +18,8 @@ describe('Single target', () => {
   let logs: string[];
   const OLD_ENV = process.env;
   process.env.SNYK_API = SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+
   it('Import & poll a repo', async () => {
     logs = Object.values(generateLogsPaths(__dirname, ORG_ID));
     const { pollingUrl } = await importTarget(ORG_ID, GITHUB_INTEGRATION_ID, {
@@ -47,6 +49,8 @@ describe('Multiple targets', () => {
   let logs: string[];
   const OLD_ENV = process.env;
   process.env.SNYK_API = SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+
   it('importTargets &  pollImportUrls multiple repos', async () => {
     logs = Object.values(generateLogsPaths(__dirname, ORG_ID));
     const pollingUrls = await importTargets([

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -16,11 +16,14 @@ describe('Import projects script', () => {
   let logs: string[];
   const OLD_ENV = process.env;
   process.env.SNYK_API = SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+
   afterAll(async () => {
     await deleteTestProjects(ORG_ID, discoveredProjects);
     await deleteLogs(logs);
     process.env = { ...OLD_ENV };
   });
+
   it('succeeds to import targets from file', async () => {
     const logFiles = generateLogsPaths(__dirname, ORG_ID);
     logs = Object.values(logFiles);
@@ -44,6 +47,8 @@ describe('Import projects script', () => {
 describe('Import skips previously imported', () => {
   const OLD_ENV = process.env;
   process.env.SNYK_API = SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+
   afterEach(async () => {
     process.env = { ...OLD_ENV };
   }, 1000);
@@ -65,6 +70,8 @@ describe('Import skips previously imported', () => {
 describe('Skips & logs issues', () => {
   const OLD_ENV = process.env;
   process.env.SNYK_API = SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+
   const discoveredProjects: Project[] = [];
   let logs: string[];
 
@@ -161,6 +168,8 @@ describe('Skips & logs issues', () => {
 describe('Error handling', () => {
   const OLD_ENV = process.env;
   process.env.SNYK_API = SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+
   afterAll(async () => {
     process.env = { ...OLD_ENV };
   }, 1000);


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Prepare to introduce `snyk-request-manager` which uses the same env vars as CLI. Rename them in preparation.