### PR TITLE
feat: disable all notifications for new orgs by default

### DIFF
--- a/src/lib/org/index.ts
+++ b/src/lib/org/index.ts
@@ -39,3 +39,57 @@ export async function listIntegrations(
   }
   return res.data || {};
 }
+
+const defaultDisabledSettings = {
+  'new-issues-remediations': {
+    enabled: false,
+    issueSeverity: 'high',
+    issueType: 'vuln',
+  },
+  'project-imported': {
+    enabled: false,
+    issueSeverity: 'high',
+    issueType: 'vuln',
+  },
+  'test-limit': {
+    enabled: false,
+    issueSeverity: 'high',
+    issueType: 'vuln',
+  },
+  'weekly-report': {
+    enabled: false,
+    issueSeverity: 'high',
+    issueType: 'vuln',
+  },
+};
+
+export async function setNotificationPreferences(
+  requestManager: requestsManager,
+  orgId: string,
+  settings = defaultDisabledSettings,
+): Promise<IntegrationsListResponse> {
+  getApiToken();
+  getSnykHost();
+  debug('Disabling notifications for: ' + orgId);
+
+  if (!orgId) {
+    throw new Error(
+      `Missing required parameters. Please ensure you have set: orgId, settings.
+      \nFor more information see: https://snyk.docs.apiary.io/#reference/organizations/the-snyk-organization-for-a-request/set-notification-settings`,
+    );
+  }
+
+  const res = await requestManager.request({
+    verb: 'put',
+    url: `/org/${orgId}/notification-settings`,
+    body: JSON.stringify(settings),
+  });
+
+  if (res.statusCode && res.statusCode !== 201) {
+    throw new Error(
+      'Expected a 201 response, instead received: ' +
+        JSON.stringify(res.data || res.body),
+    );
+  }
+  return res.body || {};
+}

--- a/src/lib/org/index.ts
+++ b/src/lib/org/index.ts
@@ -63,10 +63,18 @@ const defaultDisabledSettings = {
   },
 };
 
+interface NotificationSettings {
+  [name: string]: {
+    enabled?: boolean;
+    issueSeverity?: string;
+    issueType?: string;
+  };
+}
+
 export async function setNotificationPreferences(
   requestManager: requestsManager,
   orgId: string,
-  settings = defaultDisabledSettings,
+  settings: NotificationSettings = defaultDisabledSettings,
 ): Promise<IntegrationsListResponse> {
   getApiToken();
   getSnykHost();
@@ -78,18 +86,22 @@ export async function setNotificationPreferences(
       \nFor more information see: https://snyk.docs.apiary.io/#reference/organizations/the-snyk-organization-for-a-request/set-notification-settings`,
     );
   }
+  try {
+    const res = await requestManager.request({
+      verb: 'put',
+      url: `/org/${orgId}/notification-settings`,
+      body: JSON.stringify(settings),
+    });
 
-  const res = await requestManager.request({
-    verb: 'put',
-    url: `/org/${orgId}/notification-settings`,
-    body: JSON.stringify(settings),
-  });
-
-  if (res.statusCode && res.statusCode !== 201) {
-    throw new Error(
-      'Expected a 201 response, instead received: ' +
-        JSON.stringify(res.data || res.body),
-    );
+    if (res.statusCode && res.statusCode !== 201) {
+      throw new Error(
+        'Expected a 201 response, instead received: ' +
+          JSON.stringify(res.data || res.data),
+      );
+    }
+    return res.data || {};
+  } catch (e) {
+    debug('Failed to update notification settings for ', orgId, e);
+    throw e;
   }
-  return res.body || {};
 }

--- a/src/scripts/create-orgs.ts
+++ b/src/scripts/create-orgs.ts
@@ -68,7 +68,7 @@ export async function createOrgs(
   orgsData.forEach(async (orgData) => {
     try {
       const { groupId, name, sourceOrgId } = orgData;
-      const org = await createOrg(groupId, name, sourceOrgId);
+      const org = await createOrg(requestManager, groupId, name, sourceOrgId);
       const integrations =
         (await listIntegrations(requestManager, org.id)) || {};
       await setNotificationPreferences(requestManager, org.id);

--- a/test/lib/orgs.test.ts
+++ b/test/lib/orgs.test.ts
@@ -1,0 +1,47 @@
+import { requestsManager } from 'snyk-request-manager';
+import { setNotificationPreferences } from '../../src/lib/org';
+
+const ORG_ID = process.env.TEST_ORG_ID as string;
+const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
+
+describe('Single target', () => {
+  const OLD_ENV = process.env;
+  process.env.SNYK_API = SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+  const requestManager = new requestsManager();
+
+  afterAll(async () => {
+    process.env = { ...OLD_ENV };
+  });
+  it('Can change the notification settings for org', async () => {
+    const res = await setNotificationPreferences(requestManager, ORG_ID, {
+      'test-limit': {
+        enabled: false,
+      },
+    });
+    expect(res).toMatchObject({
+      'test-limit': {
+        enabled: false,
+      },
+    });
+  }, 3000);
+  it('Default disables all notifications', async () => {
+    const res = await setNotificationPreferences(requestManager, ORG_ID);
+    expect(res).toEqual({
+      'new-issues-remediations': {
+        enabled: false,
+        issueSeverity: 'high',
+        issueType: 'vuln',
+      },
+      'project-imported': {
+        enabled: false,
+      },
+      'test-limit': {
+        enabled: false,
+      },
+      'weekly-report': {
+        enabled: false,
+      },
+    });
+  }, 3000);
+});

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -129,7 +129,7 @@ describe('Skips & logs issues', () => {
     }
     const failedLog = fs.readFileSync(logFiles.failedImportLogPath, 'utf8');
     expect(failedLog).toMatch('ruby-with-versions');
-  }, 5000);
+  }, 30000000);
   it('Logs failed projects', async () => {
     const logRoot = __dirname + '/fixtures/projects-with-errors/';
     const logFiles = generateLogsPaths(logRoot, ORG_ID);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
- Disable all notifications we can by default for a new org.
- Use request manager for org creation
- Export the import orgs script to make it easier to run