### PR TITLE
Fix/ensure logging path set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,10 @@ const debug = debugLib('snyk:import-projects-script');
 export * from './lib';
 import { ImportProjects } from './scripts/import-projects';
 import { getImportProjectsFile } from './lib/get-import-path';
+import { getLoggingPath } from './lib/get-logging-path';
 
 try {
+  getLoggingPath()
   const importFile = getImportProjectsFile();
   ImportProjects(importFile);
 } catch (e) {

--- a/src/lib/poll-import/index.ts
+++ b/src/lib/poll-import/index.ts
@@ -11,7 +11,7 @@ import { logFailedPollUrls } from '../../log-failed-polls';
 import { logImportedProjects } from '../../log-imported-projects';
 
 const debug = debugLib('snyk:poll-import');
-const MIN_RETRY_WAIT_TIME = 30000;
+const MIN_RETRY_WAIT_TIME = 20000;
 const MAX_RETRY_COUNT = 1000;
 
 export async function pollImportUrl(

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -58,7 +58,7 @@ describe('Multiple targets', () => {
   process.env.SNYK_API = SNYK_API_TEST;
   process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
 
-  it('importTargets &  pollImportUrls multiple repos', async () => {
+  it('importTargets & pollImportUrls multiple repos', async () => {
     logs = Object.values(generateLogsPaths(__dirname, ORG_ID));
     const pollingUrls = await importTargets([
       {

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -190,6 +190,18 @@ describe('Error handling', () => {
       ),
     ).rejects.toThrow('Failed to parse targets from');
   }, 300);
+
+  it('shows correct error when SNYK_LOG_PATH is not set', async () => {
+    delete process.env.SNYK_LOG_PATH;
+    expect(
+      ImportProjects(
+        path.resolve(
+          __dirname +
+            '/fixtures/invalid-target/import-projects-invalid-target.json',
+        ),
+      ),
+    ).rejects.toThrow('Please set the SNYK_LOG_PATH e.g. export SNYK_LOG_PATH');
+  }, 300);
 });
 
 describe('Polling', () => {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Ensure logging path is set before starting, reduce poll interval to 20s instead of 30s.