### PR TITLE
feat: create the log folder if it is missing

### DIFF
--- a/src/lib/get-logging-path.ts
+++ b/src/lib/get-logging-path.ts
@@ -1,9 +1,20 @@
+import * as fs from 'fs';
+
 export function getLoggingPath(): string {
   const snykLogPath = process.env.SNYK_LOG_PATH;
   if (!snykLogPath) {
     throw new Error(
       `Please set the SNYK_LOG_PATH e.g. export SNYK_LOG_PATH='~/my/path'`,
     );
+  }
+  if (!fs.existsSync(snykLogPath)) {
+    try {
+      fs.mkdirSync(snykLogPath);
+    } catch (e) {
+      throw new Error(
+        `Failed to auto create the path ${snykLogPath} provided in the SNYK_LOG_PATH. Please check this variable is set correctly`,
+      );
+    }
   }
   return snykLogPath;
 }

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -106,7 +106,8 @@ describe('Skips & logs issues', () => {
   }, 300);
 
   it('Logs failed when API errors', async () => {
-    const logRoot = __dirname + '/fixtures/failed-batch/';
+    // this folder does not exist and will be created on run
+    const logRoot = __dirname + '/fixtures/failed-batch-log/';
     const logFiles = generateLogsPaths(logRoot, ORG_ID);
     logs = Object.values(logFiles);
     const exit = jest.spyOn(process, 'exit').mockImplementationOnce(() => {
@@ -129,6 +130,12 @@ describe('Skips & logs issues', () => {
     }
     const failedLog = fs.readFileSync(logFiles.failedImportLogPath, 'utf8');
     expect(failedLog).toMatch('ruby-with-versions');
+    // delete auto generated folder
+    try {
+      fs.unlinkSync(logRoot);
+    } catch (e) {
+      // ignore
+    }
   }, 30000000);
   it('Logs failed projects', async () => {
     const logRoot = __dirname + '/fixtures/projects-with-errors/';


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Create the logging directory if we can when the path provided doesn't yet exist https://github.com/snyk-tech-services/snyk-api-import/issues/49