### PR TITLE
fix: imported targets number to include skipped

### DIFF
--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -83,13 +83,14 @@ export async function ImportProjects(
       targetIndex + concurrentTargets,
     );
     const currentTargets = skippedTargets + targetIndex + 1;
+    const fullTargetsNumber = filteredTargets.length + skippedTargets;
     let currentBatchEnd = currentTargets + concurrentTargets - 1;
-    if (currentBatchEnd > filteredTargets.length) {
+    if (currentBatchEnd > fullTargetsNumber) {
       currentBatchEnd = currentTargets;
     }
-    const batchProgressMessages = `Importing batch ${currentTargets} - ${currentBatchEnd} out of ${
-      filteredTargets.length
-    } ${skippedTargets > 0 ? `(skipped ${skippedTargets})` : ''}`;
+    const batchProgressMessages = `Importing batch ${currentTargets} - ${currentBatchEnd} out of ${fullTargetsNumber} ${
+      skippedTargets > 0 ? `(skipped ${skippedTargets})` : ''
+    }`;
     debug(batchProgressMessages);
     logImportedBatch(batchProgressMessages);
     const pollingUrlsAndContext = await importTargets(batch, loggingPath);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Count the imported targets in *all* possible targets for counter pruposes