### PR TITLE
feat: use latest snyk-request-manager with user-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sleep-promise": "8.0.1",
     "snyk": "1.336.0",
     "snyk-config": "^3.0.0",
-    "snyk-request-manager": "1.1.0",
+    "snyk-request-manager": "1.2.1",
     "source-map-support": "^0.5.16",
     "tslib": "^1.10.0"
   },

--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -97,7 +97,9 @@ export async function importTargets(
   loggingPath = getLoggingPath(),
 ): Promise<string[]> {
   const pollingUrls: string[] = [];
-  const requestManager = new requestsManager({ period: 15000 });
+  const requestManager = new requestsManager({
+    userAgentPrefix: 'snyk-api-import',
+  });
   // TODO: validate targets
   let failed = 0;
   const concurrentImports = getConcurrentImportsNumber();

--- a/src/scripts/create-orgs.ts
+++ b/src/scripts/create-orgs.ts
@@ -61,8 +61,9 @@ export async function createOrgs(
   } catch (e) {
     throw new Error(`Failed to parse orgs from ${fileName}`);
   }
-  const requestManager = new requestsManager();
-
+  const requestManager = new requestsManager({
+    userAgentPrefix: 'snyk-api-import',
+  });
   debug(`Loaded ${orgsData.length} orgs to create ${Date.now()}`);
   const createdOrgs: CreatedOrg[] = [];
   orgsData.forEach(async (orgData) => {

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -23,7 +23,9 @@ describe('Single target', () => {
 
   it('Import & poll a repo', async () => {
     logs = Object.values(generateLogsPaths(__dirname, ORG_ID));
-    const requestManager = new requestsManager();
+    const requestManager = new requestsManager({
+      userAgentPrefix: 'snyk-api-import:tests',
+    });
     const { pollingUrl } = await importTarget(
       requestManager,
       ORG_ID,

--- a/test/lib/orgs.test.ts
+++ b/test/lib/orgs.test.ts
@@ -8,8 +8,9 @@ describe('Single target', () => {
   const OLD_ENV = process.env;
   process.env.SNYK_API = SNYK_API_TEST;
   process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
-  const requestManager = new requestsManager();
-
+  const requestManager = new requestsManager({
+    userAgentPrefix: 'snyk-api-import:tests',
+  });
   afterAll(async () => {
     process.env = { ...OLD_ENV };
   });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Use latest requests manager that creates user-agent for logging purposes