### PR TITLE
feat: introduce octokit to fetch Github repos & orgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "homepage": "https://github.com/snyk-tech-services/snyk-api-import#readme",
   "dependencies": {
+    "@octokit/rest": "18.0.6",
     "@snyk/configstore": "^3.2.0-rc1",
     "axios": "^0.20.0",
     "debug": "4.3.0",

--- a/src/scripts/github/list-orgs.ts
+++ b/src/scripts/github/list-orgs.ts
@@ -1,0 +1,24 @@
+import { Octokit } from "@octokit/rest";
+
+interface OrgData {
+  name: string;
+  id: number;
+  url: string;
+}
+export async function listGithubOrgs(): Promise<OrgData[]> {
+  const githubToken = process.env.GITHUB_TOKEN;
+  if (!githubToken) {
+    throw new Error(
+      `Please set the GITHUB_TOKEN e.g. export GITHUB_TOKEN='mypersonalaccesstoken123'`,
+    );
+  }
+  const octokit = new Octokit({auth: githubToken});
+  const res = await octokit.orgs.listForAuthenticatedUser();
+  const orgsData = res && res.data;
+
+  if (!orgsData.length) {
+    return [];
+  }
+  const orgs: OrgData[] = orgsData.map(org => ({ name: org.login, id: org.id, url: org.url}));
+  return orgs;
+}

--- a/src/scripts/github/list-repos.ts
+++ b/src/scripts/github/list-repos.ts
@@ -1,0 +1,34 @@
+import { Octokit } from '@octokit/rest';
+
+interface RepoData {
+  fork: boolean;
+  branch: string;
+  owner: string;
+  name: string;
+}
+export async function listGithubRepos(orgName: string): Promise<RepoData[]> {
+  const githubToken = process.env.GITHUB_TOKEN;
+  if (!githubToken) {
+    throw new Error(
+      `Please set the GITHUB_TOKEN e.g. export GITHUB_TOKEN='mypersonalaccesstoken123'`,
+    );
+  }
+  const octokit = new Octokit({ auth: githubToken });
+  const res = await octokit.repos.listForOrg({
+    org: orgName,
+  });
+  const repoData = res && res.data;
+
+  if (!repoData.length) {
+    return [];
+  }
+  const repos: RepoData[] = repoData
+    .filter((repo) => !repo.archived)
+    .map((repo) => ({
+      fork: repo.fork,
+      name: repo.name,
+      owner: repo.owner.login,
+      branch: repo.default_branch,
+    }));
+  return repos;
+}

--- a/test/scripts/github.test.ts
+++ b/test/scripts/github.test.ts
@@ -1,0 +1,23 @@
+import { listGithubOrgs } from "../../src/scripts/github/list-orgs";
+import { listGithubRepos } from "../../src/scripts/github/list-repos";
+
+describe('listGithubOrgs script', () => {
+  const GITHUB_ORG_NAME = process.env.TEST_GH_ORG_NAME;
+  it('list orgs', async () => {
+    const orgs = await listGithubOrgs();
+    expect(orgs[0]).toEqual({
+      name: expect.any(String),
+      id: expect.any(Number),
+      url: expect.any(String)
+    });
+  });
+  it('list repos', async () => {
+    const orgs = await listGithubRepos(GITHUB_ORG_NAME as string);
+    expect(orgs[0]).toEqual({
+      name: expect.any(String),
+      owner: expect.any(String),
+      branch: expect.any(String),
+      fork: expect.any(Boolean),
+    });
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Introduce oktokit & ability to fetch orgs & repos to be used later to generate import data.