### PR TITLE
feat: introduce yargs & set default command for backwards compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ WHat you will need to have setup in advance:
 - Recommended: have notifications disabled for emails etc to avoid receiving import notifications
 - Recommended: have the fix PRs and PR checks disabled until import is complete to avoid sending extra requests to SCMs (Github/Gitlab/Bitbucket etc)
 
-
-
-### Setup
-`npm i`
+### Basic CLI commands
+By default the `import` command
+- `help` - show help & all available commands and their options
+- `import` - kick off a an API powered import of repos/targets into existing Snyk orgs defined in [import configuration file](#to-kick-off-an-import).
 
 ## To kick off an import
 Any logs will be generated at `SNYK_LOG_PATH` directory.
@@ -93,3 +93,7 @@ Any logs will be generated at `SNYK_LOG_PATH` directory.
 
 ### 3. Download & run
 Grab a binary from the [releases page](https://github.com/snyk-tech-services/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos`
+
+
+### Development Setup
+`npm i`

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "snyk-config": "^3.0.0",
     "snyk-request-manager": "1.2.1",
     "source-map-support": "^0.5.16",
-    "tslib": "^1.10.0"
+    "tslib": "^1.10.0",
+    "yargs": "16.0.3"
   },
   "devDependencies": {
     "@types/debug": "4.1.5",

--- a/src/cmds/import.ts
+++ b/src/cmds/import.ts
@@ -1,0 +1,22 @@
+import * as debugLib from 'debug';
+const debug = debugLib('snyk:import-projects-script');
+
+import { ImportProjects } from '../scripts/import-projects';
+import { getImportProjectsFile } from '../lib/get-import-path';
+import { getLoggingPath } from '../lib/get-logging-path';
+
+export const command = ['import', '$0'];
+export const desc = 'Kick off API powered import';
+export const builder = {};
+export const aliases = ['i'];
+
+export async function handler(): Promise<void> {
+  try {
+    getLoggingPath();
+    const importFile = getImportProjectsFile();
+    ImportProjects(importFile);
+  } catch (e) {
+    debug('Failed to kick off import.\n' + e);
+    console.error('ERROR! Try running with `DEBUG=snyk* snyk-import`');
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,10 @@
 #!/usr/bin/env node
 
-import * as debugLib from 'debug';
-const debug = debugLib('snyk:import-projects-script');
-
+import * as yargs from 'yargs';
 export * from './lib';
-import { ImportProjects } from './scripts/import-projects';
-import { getImportProjectsFile } from './lib/get-import-path';
-import { getLoggingPath } from './lib/get-logging-path';
 
-try {
-  getLoggingPath()
-  const importFile = getImportProjectsFile();
-  ImportProjects(importFile);
-} catch (e) {
-  debug('Failed to kick off import.\n' + e);
-  console.error('ERROR! Try running with `DEBUG=snyk* snyk-import`')
-}
+yargs
+  .commandDir('cmds')
+  .demandCommand()
+  .help()
+  .argv

--- a/test/system/__snapshots__/basic.test.ts.snap
+++ b/test/system/__snapshots__/basic.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`\`snyk-api-import help <...>\` Shows help text as expected 1`] = `
+"index.js
+
+Kick off API powered import
+
+Commands:
+  index.js import  Kick off API powered import            [default] [aliases: i]
+
+Options:
+  --version  Show version number                                       [boolean]
+  --help     Show help                                                 [boolean]"
+`;

--- a/test/system/basic.test.ts
+++ b/test/system/basic.test.ts
@@ -1,0 +1,23 @@
+import { exec } from 'child_process';
+import { sep } from 'path';
+const main = './dist/index.js'.replace(/\//g, sep);
+
+describe('`snyk-api-import help <...>`', () => {
+  const OLD_ENV = process.env;
+  process.env.SNYK_API = process.env.SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+
+  afterAll(async () => {
+    process.env = { ...OLD_ENV };
+  });
+  it('Shows help text as expected', async (done) => {
+    return exec(`node ${main} help`, (err, stdout) => {
+      if (err) {
+        throw err;
+      }
+      expect(err).toBeNull();
+      expect(stdout.trim()).toMatchSnapshot();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Introduce `yargs` to help manage multiple commands, set the import to be default and run when no command is provided for backwards compatibility.