### PR TITLE
chore: drop unused log name variable IMPORT_PROJECTS_FILE_NAME

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,4 @@
 export const IMPORT_LOG_NAME = 'imported-targets.log';
-export const IMPORT_PROJECTS_FILE_NAME= 'import-projects.json';
 export const FAILED_LOG_NAME = 'failed-imports.log';
 export const FAILED_PROJECTS_LOG_NAME = 'failed-projects.log';
 export const FAILED_POLLS_LOG_NAME = 'failed-polls.log';

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -2,12 +2,12 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 import { ImportProjects } from '../../src/scripts/import-projects';
-import { IMPORT_PROJECTS_FILE_NAME } from '../../src/common';
 import { deleteTestProjects } from '../delete-test-projects';
 import { Project } from '../../src/lib/types';
 import { generateLogsPaths } from '../generate-log-file-names';
 import { deleteLogs } from '../delete-logs';
 
+const IMPORT_PROJECTS_FILE_NAME='import-projects.json';
 const ORG_ID = process.env.TEST_ORG_ID as string;
 const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Drop unused log name variable `IMPORT_PROJECTS_FILE_NAME`