### PR TITLE
feat: user request manager for polling urls

### DIFF
--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -95,13 +95,11 @@ export async function importTarget(
 }
 
 export async function importTargets(
+  requestManager: requestsManager,
   targets: ImportTarget[],
   loggingPath = getLoggingPath(),
 ): Promise<string[]> {
   const pollingUrls: string[] = [];
-  const requestManager = new requestsManager({
-    userAgentPrefix: 'snyk-api-import',
-  });
   // TODO: validate targets
   let failed = 0;
   const concurrentImports = getConcurrentImportsNumber();

--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -1,5 +1,7 @@
 import * as debugLib from 'debug';
 import * as path from 'path';
+import { requestsManager } from 'snyk-request-manager';
+
 import { loadFile } from '../load-file';
 import { importTargets, pollImportUrls } from '../lib';
 import { Project, ImportTarget } from '../lib/types';
@@ -78,6 +80,9 @@ export async function importProjects(
       `Skipped previously imported ${skippedTargets}/${targets.length} targets`,
     );
   }
+  const requestManager = new requestsManager({
+    userAgentPrefix: 'snyk-api-import',
+  });
   for (
     let targetIndex = 0;
     targetIndex < filteredTargets.length;
@@ -98,8 +103,8 @@ export async function importProjects(
     }`;
     debug(batchProgressMessages);
     logImportedBatch(batchProgressMessages);
-    const pollingUrlsAndContext = await importTargets(batch, loggingPath);
-    projects.push(...(await pollImportUrls(pollingUrlsAndContext)));
+    const pollingUrlsAndContext = await importTargets(requestManager, batch, loggingPath);
+    projects.push(...(await pollImportUrls(requestManager,pollingUrlsAndContext)));
   }
   return { projects, skippedTargets, filteredTargets, targets };
 }

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -37,7 +37,7 @@ describe('Single target', () => {
       },
     );
     expect(pollingUrl).not.toBeNull();
-    const projects = await pollImportUrl(pollingUrl);
+    const projects = await pollImportUrl(requestManager, pollingUrl);
     expect(projects[0]).toMatchObject({
       projectUrl: expect.any(String),
       success: true,
@@ -62,7 +62,10 @@ describe('Multiple targets', () => {
 
   it('importTargets & pollImportUrls multiple repos', async () => {
     logs = Object.values(generateLogsPaths(__dirname, ORG_ID));
-    const pollingUrls = await importTargets([
+    const requestManager = new requestsManager({
+      userAgentPrefix: 'snyk-api-import:tests',
+    });
+    const pollingUrls = await importTargets(requestManager, [
       {
         orgId: ORG_ID,
         integrationId: INTEGRATION_ID,
@@ -83,7 +86,7 @@ describe('Multiple targets', () => {
       },
     ]);
     expect(pollingUrls.length >= 1).toBeTruthy();
-    const projects = await pollImportUrls(pollingUrls);
+    const projects = await pollImportUrls(requestManager, pollingUrls);
     // at least one job successfully finished
     expect(projects[0]).toMatchObject({
       projectUrl: expect.any(String),


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Use request manager to poll urls as well
