### PR TITLE
feat: generate org data for Github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,94 +6,25 @@
 
 Snyk helps you find, fix and monitor for known vulnerabilities in your dependencies, both on an ad hoc basis and as part of your CI (Build) system.
 
-## Snyk api import
+# Snyk api import
 Snyk API project importer. This script is intended to help import projects into Snyk with a controlled pace utilizing available [Snyk APIs](https://snyk.docs.apiary.io/) to avoid rate limiting from Github/Gitlab/Bitbucket etc and to provide a stable import. The script will kick off an import in batches, wait for completion and then keep going. Any failed requests will be retried before they are considered a failure and logged.
 
 If you need to adjust concurrency you can stop the script, change the concurrency variable and start again. It will skip previous repos/targets that have been requested for import.
 
-WHat you will need to have setup in advance:
+What you will need to have setup in advance:
+- your [Snyk organizations](docs/orgs.md) should be setup before running an import
+- your Snyk organizations configured with some connection to SCM (Github/Gitlab/Bitbucket etc) as you will need the `integrationId` to generate the import files.
+- Recommended: have [notifications disabled](https://snyk.docs.apiary.io/#reference/organizations/notification-settings/set-notification-settings) for emails etc to avoid receiving import notifications
+- Recommended: have the [fix PRs and PR checks disabled](https://snyk.docs.apiary.io/#reference/integrations/integration-settings/update) until import is complete to avoid sending extra requests to SCMs (Github/Gitlab/Bitbucket etc)
 
-- your Snyk organizations should be setup before running an import
-- your Snyk organizations configured with some connection to SCM (Github/Gitlab/Bitbucket etc) as you will need the integrationId to generate the import files.
-- Recommended: have notifications disabled for emails etc to avoid receiving import notifications
-- Recommended: have the fix PRs and PR checks disabled until import is complete to avoid sending extra requests to SCMs (Github/Gitlab/Bitbucket etc)
-
-### Basic CLI commands
-By default the `import` command
+# Usage
+By default the `import` command will run if no command specified.
 - `help` - show help & all available commands and their options
+- `orgs:data` - generate data required to create Orgs via API.
 - `import` - kick off a an API powered import of repos/targets into existing Snyk orgs defined in [import configuration file](#to-kick-off-an-import).
 
-## To kick off an import
-Any logs will be generated at `SNYK_LOG_PATH` directory.
-
-### 1. Create the `import-projects.json` file:
-  - `orgId` - Can be found in https://app.snyk.io/org/YOUR_ORG/manage/settings
-  - `integrationId` - Can be found in Integrations menu for each SCM https://app.snyk.io/org/YOUR_ORG/manage/settings
-  - `target`, `files`, `exclusionGlobs` - see our [Import API documentation](https://snyk.docs.apiary.io/#reference/integrations/import-projects/import) for more info.
-
-  *Note*: For a repo that may have 200+ manifest files it is recommended to split this import into multiple by targeting specific files. Importing hundreds of files at once from 1 repo can cause the import to result in some errors/failures. Splitting it into to target some files, or some folders only will benefit from the re-tries and yield a smaller load on the source control management system being used. Populate the the `files` property to accomplish this in the import JSON.
-
-  If you have any tests ot fixtures that should be ignored, please set the `exclusionGLobs` property:
-  > a comma-separated list of up to 10 folder names to exclude from scanning. If not specified, it will default to "fixtures, tests, __tests__, node_modules". If an empty string is provided - no folders will be excluded
-
-
-#### Example:  Bitbucket Server
-
-```
-{
-  "targets": [
-    {
-      "orgId": "******",
-      "integrationId": "******",
-      "target": {
-        "repoSlug": "snyk-fixtures",
-        "name": "Snyk snyk-fixtures",
-        "projectKey": "PROJECT"
-      },
-      "files": [
-        {
-          "path": "package.json"
-        },
-        {
-          "path": "package/package.json"
-        },
-        {
-          "path": "Gemfile.lock"
-        }
-      ],
-      "exclusionGlobs": "fixtures, test"
-    },
-  ]
-}
-```
-
-#### Example: Github.com | Github Enterprise
-```
-{
-  "targets": [
-    {
-      "orgId": "******",
-      "integrationId": "******",
-      "target": {
-        "name": "shallow-goof-policy",
-        "owner": "snyk-fixtures",
-        "branch": "master"
-      },
-      "exclusionGlobs": "fixtures, test"
-    }
-  ]
-}
-```
-### 2. Set the env vars mentioned:
-  - `SNYK_IMPORT_PATH`- the path to the import file
-  - `SNYK_TOKEN` - your [Snyk api token](https://app.snyk.io/account)
-  - `SNYK_LOG_PATH` - the path to folder where all logs should be saved,it is recommended creating a dedicated logs folder per import you have running. (Note: all logs will append)
-  - `CONCURRENT_IMPORTS` (optional) defaults to 15 repos at a time, which is the recommended amount to import at once as a max.  Just 1 repo may have many projects inside which can trigger a many files at once to be requested from the user's SCM instance and some may have rate limiting in place. This script aims to help reduce the risk of hitting a rate limit.
-  - `SNYK_API` (optional) defaults to `https://snyk.io/api/v1`
-
-### 3. Download & run
-Grab a binary from the [releases page](https://github.com/snyk-tech-services/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos`
-
-
-### Development Setup
-`npm i`
+# Table of Contents
+- Utilities
+  - [Generating orgs in Snyk](docs/orgs.md)
+- [Kicking off an import](docs/import.md)
+- [Contributing](.github/CONTRIBUTING.md)

--- a/docs/import.md
+++ b/docs/import.md
@@ -1,0 +1,71 @@
+# To kick off an import
+Any logs will be generated at `SNYK_LOG_PATH` directory.
+
+### 1. Create the `import-projects.json` file:
+  - `orgId` - Can be found in https://app.snyk.io/org/YOUR_ORG/manage/settings
+  - `integrationId` - Can be found in Integrations menu for each SCM https://app.snyk.io/org/YOUR_ORG/manage/settings
+  - `target`, `files`, `exclusionGlobs` - see our [Import API documentation](https://snyk.docs.apiary.io/#reference/integrations/import-projects/import) for more info.
+
+  *Note*: For a repo that may have 200+ manifest files it is recommended to split this import into multiple by targeting specific files. Importing hundreds of files at once from 1 repo can cause the import to result in some errors/failures. Splitting it into to target some files, or some folders only will benefit from the re-tries and yield a smaller load on the source control management system being used. Populate the the `files` property to accomplish this in the import JSON.
+
+  If you have any tests ot fixtures that should be ignored, please set the `exclusionGLobs` property:
+  > a comma-separated list of up to 10 folder names to exclude from scanning. If not specified, it will default to "fixtures, tests, __tests__, node_modules". If an empty string is provided - no folders will be excluded
+
+
+#### Example:  Bitbucket Server
+
+```
+{
+  "targets": [
+    {
+      "orgId": "******",
+      "integrationId": "******",
+      "target": {
+        "repoSlug": "snyk-fixtures",
+        "name": "Snyk snyk-fixtures",
+        "projectKey": "PROJECT"
+      },
+      "files": [
+        {
+          "path": "package.json"
+        },
+        {
+          "path": "package/package.json"
+        },
+        {
+          "path": "Gemfile.lock"
+        }
+      ],
+      "exclusionGlobs": "fixtures, test"
+    },
+  ]
+}
+```
+
+#### Example: Github.com | Github Enterprise
+```
+{
+  "targets": [
+    {
+      "orgId": "******",
+      "integrationId": "******",
+      "target": {
+        "name": "shallow-goof-policy",
+        "owner": "snyk-fixtures",
+        "branch": "master"
+      },
+      "exclusionGlobs": "fixtures, test"
+    }
+  ]
+}
+```
+### 2. Set the env vars mentioned:
+  - `SNYK_IMPORT_PATH`- the path to the import file
+  - `SNYK_TOKEN` - your [Snyk api token](https://app.snyk.io/account)
+  - `SNYK_LOG_PATH` - the path to folder where all logs should be saved,it is recommended creating a dedicated logs folder per import you have running. (Note: all logs will append)
+  - `CONCURRENT_IMPORTS` (optional) defaults to 15 repos at a time, which is the recommended amount to import at once as a max.  Just 1 repo may have many projects inside which can trigger a many files at once to be requested from the user's SCM instance and some may have rate limiting in place. This script aims to help reduce the risk of hitting a rate limit.
+  - `SNYK_API` (optional) defaults to `https://snyk.io/api/v1`
+
+### 3. Download & run
+Grab a binary from the [releases page](https://github.com/snyk-tech-services/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos`
+

--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -1,0 +1,18 @@
+# Creating Organizations in Snyk
+
+Before an import can begin Snyk needs to be setup with the Organizations you will populate with projects.
+
+It is recommended to have as many Organizations in Snyk as you have in the source you are importing from. So for Github this would mean mirroring the Github organizations in Snyk. The tool provides a utility that can be used to make this simpler when using Groups & Organizations in Snyk.
+
+## `orgs:data`
+
+### Github.com
+1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GH_TOKEN=your_personal_access_token`
+2. Run the command to generate Org data:
+  `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id>`
+3. Use the generated data to feed into Snyk [Orgs API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) to generate the organizations within a group.
+
+
+## Recommendations
+- have [notifications disabled](https://snyk.docs.apiary.io/#reference/organizations/notification-settings/set-notification-settings) for emails etc to avoid receiving import notifications
+- have the [fix PRs and PR checks disabled](https://snyk.docs.apiary.io/#reference/integrations/integration-settings/update) until import is complete to avoid sending extra requests to SCMs (Github/Gitlab/Bitbucket etc)

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -1,0 +1,62 @@
+import * as debugLib from 'debug';
+const debug = debugLib('snyk:generate-data-script');
+
+import { getLoggingPath } from '../lib/get-logging-path';
+import {
+  generateOrgImportDataFile,
+  Sources,
+} from '../scripts/generate-org-data';
+
+export const command = ['orgs:data'];
+export const desc =
+  'Generate data required for Orgs to be created via API by mirroring a given source.\n';
+export const builder = {
+  sourceOrgPublicId: {
+    required: false,
+    default: undefined,
+  },
+  groupId: {
+    required: true,
+    default: undefined,
+    desc: 'Public id of the group in Snyk (available on group settings)',
+  },
+  source: {
+    required: true,
+    default: Sources.GITHUB,
+    choices: [Sources.GITHUB],
+    desc: 'The source of the targets to be imported e.g. Github',
+  },
+};
+
+const entityName = {
+  github: 'org',
+};
+
+export async function handler(argv: {
+  source: Sources;
+  groupId: string;
+  sourceOrgPublicId?: string;
+}): Promise<void> {
+  try {
+    getLoggingPath();
+    const { source, sourceOrgPublicId, groupId } = argv;
+    debug('ℹ️  Options: ' + JSON.stringify(argv));
+
+    const res = await generateOrgImportDataFile(
+      source,
+      groupId,
+      sourceOrgPublicId,
+    );
+    const orgsMessage =
+      res.orgs.length > 0
+        ? `Found ${res.orgs.length} ${entityName[source]}(s). Written the data to file: ${res.fileName}`
+        : `⚠ No ${entityName[source]}(s) found!`;
+
+    console.log(orgsMessage);
+  } catch (e) {
+    debug('Failed to generate data.\n' + e);
+    console.error(
+      `ERROR! Failed to generate data. Try running with \`DEBUG=snyk* <command> for more info\`.\nERROR: ${e}`,
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,6 @@ export * from './lib';
 
 yargs
   .commandDir('cmds')
-  .demandCommand()
   .help()
+  .demandCommand()
   .argv

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,12 @@ export interface FilePath {
   path: string;
 }
 
+export interface CreateOrgData {
+  groupId: string;
+  name: string;
+  sourceOrgId?: string;
+}
+
 export enum Status {
   PENDING = 'pending',
   FAILED = 'failed',

--- a/src/scripts/create-orgs.ts
+++ b/src/scripts/create-orgs.ts
@@ -7,17 +7,9 @@ import { getLoggingPath } from '../lib/get-logging-path';
 import { listIntegrations, setNotificationPreferences } from '../lib/org';
 import { requestsManager } from 'snyk-request-manager';
 import { getImportProjectsFile } from '../lib/get-import-path';
+import { CreateOrgData } from '../lib/types';
 
 const debug = debugLib('snyk:create-orgs-script');
-
-interface CreateOrgData {
-  groupId: string;
-  name: string;
-  sourceOrgId?: string;
-  integrations: {
-    [name: string]: string;
-  };
-}
 
 export async function logCreatedOrg(
   groupId: string,

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -1,0 +1,42 @@
+import { CreateOrgData } from '../lib/types';
+import { writeFile } from '../write-file';
+import { GithubOrgData, listGithubOrgs } from './github';
+
+export enum Sources {
+  GITHUB = 'github',
+}
+
+async function githubOrganizations(): Promise<{ name: string }[]> {
+  const ghOrgs: GithubOrgData[] = await listGithubOrgs();
+  return ghOrgs;
+}
+
+const sourceGenerators = {
+  [Sources.GITHUB]: githubOrganizations,
+};
+
+export async function generateOrgImportDataFile(
+  source: Sources,
+  groupId: string,
+  sourceOrgId?: string,
+): Promise<{ orgs: CreateOrgData[]; fileName: string }> {
+  const orgData: CreateOrgData[] = [];
+
+  const toplevelEntities = await sourceGenerators[source]();
+
+  for (const org in toplevelEntities) {
+    const data: CreateOrgData = {
+      name: toplevelEntities[org].name,
+      groupId,
+    };
+    if (sourceOrgId) {
+      data.sourceOrgId = sourceOrgId;
+    }
+    orgData.push(data);
+  }
+  const fileName = `group-${groupId}-github-com-orgs.json`;
+  await writeFile(fileName, ({
+    orgs: orgData,
+  } as unknown) as JSON);
+  return { orgs: orgData, fileName };
+}

--- a/src/scripts/github/index.ts
+++ b/src/scripts/github/index.ts
@@ -1,0 +1,1 @@
+export * from './list-orgs';

--- a/src/scripts/github/list-orgs.ts
+++ b/src/scripts/github/list-orgs.ts
@@ -1,24 +1,28 @@
-import { Octokit } from "@octokit/rest";
+import { Octokit } from '@octokit/rest';
 
-interface OrgData {
+export interface GithubOrgData {
   name: string;
   id: number;
   url: string;
 }
-export async function listGithubOrgs(): Promise<OrgData[]> {
+export async function listGithubOrgs(): Promise<GithubOrgData[]> {
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
     throw new Error(
       `Please set the GITHUB_TOKEN e.g. export GITHUB_TOKEN='mypersonalaccesstoken123'`,
     );
   }
-  const octokit = new Octokit({auth: githubToken});
+  const octokit = new Octokit({ auth: githubToken });
   const res = await octokit.orgs.listForAuthenticatedUser();
   const orgsData = res && res.data;
 
   if (!orgsData.length) {
     return [];
   }
-  const orgs: OrgData[] = orgsData.map(org => ({ name: org.login, id: org.id, url: org.url}));
+  const orgs: GithubOrgData[] = orgsData.map((org) => ({
+    name: org.login,
+    id: org.id,
+    url: org.url,
+  }));
   return orgs;
 }

--- a/src/write-file.ts
+++ b/src/write-file.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs';
+import * as debugLib from 'debug';
+import { getLoggingPath } from './lib/get-logging-path';
+const debug = debugLib('snyk:write-file');
+
+export async function writeFile(
+  name: string,
+  content: JSON,
+): Promise<void> {
+  const ROOT_DIR = getLoggingPath();
+  const filename = `${ROOT_DIR}/${name}`;
+
+  try {
+    return await fs.writeFileSync(filename, JSON.stringify(content));
+  } catch (error) {
+    debug(error);
+    throw new Error(`Failed to write to file: ${filename}`);
+  }
+}

--- a/test/delete-files.ts
+++ b/test/delete-files.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 
-export function deleteLogs(logs: string[]): void {
+export function deleteFiles(logs: string[]): void {
   logs.forEach((path) => {
     try {
       fs.unlinkSync(path);

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -8,7 +8,7 @@ import {
 import { Project } from '../../src/lib/types';
 import { deleteTestProjects } from '../delete-test-projects';
 import { generateLogsPaths } from '../generate-log-file-names';
-import { deleteLogs } from '../delete-logs';
+import { deleteFiles } from '../delete-files';
 
 const ORG_ID = process.env.TEST_ORG_ID as string;
 const INTEGRATION_ID = process.env.TEST_INTEGRATION_ID as string;
@@ -51,7 +51,7 @@ describe('Single target', () => {
   }, 30000000);
   afterAll(async () => {
     await deleteTestProjects(ORG_ID, discoveredProjects);
-    await deleteLogs(logs);
+    await deleteFiles(logs);
     process.env = { ...OLD_ENV };
   });
 });
@@ -101,7 +101,7 @@ describe('Multiple targets', () => {
   }, 30000000);
   afterAll(async () => {
     await deleteTestProjects(ORG_ID, discoveredProjects);
-    await deleteLogs(logs);
+    await deleteFiles(logs);
     process.env = { ...OLD_ENV };
   });
 });

--- a/test/scripts/generate-org-data.test.ts
+++ b/test/scripts/generate-org-data.test.ts
@@ -1,0 +1,43 @@
+import {
+  generateOrgImportDataFile,
+  Sources,
+} from '../../src/scripts/generate-org-data';
+import { deleteFiles } from '../delete-files';
+
+describe('generateOrgImportDataFile Github script', () => {
+  const OLD_ENV = process.env;
+  process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
+  process.env.SNYK_LOG_PATH = __dirname;
+  afterAll(async () => {
+    process.env = { ...OLD_ENV };
+    await deleteFiles(['groupIdExample-sourceOrgIdExample-orgs.json']);
+  });
+  it('generate Github Orgs data', async () => {
+    const groupId = 'groupIdExample';
+    const sourceOrgId = 'sourceOrgIdExample';
+
+    const res = await generateOrgImportDataFile(
+      Sources.GITHUB,
+      groupId,
+      sourceOrgId,
+    );
+    expect(res.fileName).toEqual('group-groupIdExample-github-com-orgs.json');
+    expect(res.orgs.length > 0).toBeTruthy();
+    expect(res.orgs[0]).toEqual({
+      name: expect.any(String),
+      groupId,
+      sourceOrgId,
+    });
+  });
+  it('generate Github Orgs data without sourceOrgId', async () => {
+    const groupId = 'groupIdExample';
+
+    const res = await generateOrgImportDataFile(Sources.GITHUB, groupId);
+    expect(res.fileName).toEqual('group-groupIdExample-github-com-orgs.json');
+    expect(res.orgs.length > 0).toBeTruthy();
+    expect(res.orgs[0]).toEqual({
+      name: expect.any(String),
+      groupId,
+    });
+  });
+});

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -5,7 +5,7 @@ import { importProjects } from '../../src/scripts/import-projects';
 import { deleteTestProjects } from '../delete-test-projects';
 import { Project } from '../../src/lib/types';
 import { generateLogsPaths } from '../generate-log-file-names';
-import { deleteLogs } from '../delete-logs';
+import { deleteFiles } from '../delete-files';
 
 const ORG_ID = process.env.TEST_ORG_ID as string;
 const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
@@ -23,7 +23,7 @@ describe('Import projects script', () => {
 
   afterAll(async () => {
     await deleteTestProjects(ORG_ID, discoveredProjects);
-    await deleteLogs(logs);
+    await deleteFiles(logs);
     process.env = { ...OLD_ENV };
   });
 
@@ -80,7 +80,7 @@ describe('Skips & logs issues', () => {
   let logs: string[];
 
   afterEach(async () => {
-    await deleteLogs(logs);
+    await deleteFiles(logs);
     process.env = { ...OLD_ENV };
   }, 1000);
 

--- a/test/scripts/polling.test.ts
+++ b/test/scripts/polling.test.ts
@@ -7,7 +7,7 @@ import { importProjects } from '../../src/scripts/import-projects';
 import { deleteTestProjects } from '../delete-test-projects';
 import { Project } from '../../src/lib/types';
 import { generateLogsPaths } from '../generate-log-file-names';
-import { deleteLogs } from '../delete-logs';
+import { deleteFiles } from '../delete-files';
 
 const ORG_ID = process.env.TEST_ORG_ID as string;
 const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
@@ -22,7 +22,7 @@ describe('Logs failed polls', () => {
 
   afterAll(async () => {
     await deleteTestProjects(ORG_ID, discoveredProjects);
-    await deleteLogs(logs);
+    await deleteFiles(logs);
     process.env = { ...OLD_ENV };
   });
 

--- a/test/system/__snapshots__/basic.test.ts.snap
+++ b/test/system/__snapshots__/basic.test.ts.snap
@@ -6,7 +6,10 @@ exports[`\`snyk-api-import help <...>\` Shows help text as expected 1`] = `
 Kick off API powered import
 
 Commands:
-  index.js import  Kick off API powered import            [default] [aliases: i]
+  index.js import     Kick off API powered import         [default] [aliases: i]
+  index.js orgs:data  Generate data required for Orgs to be created via API by
+                      mirroring a given source.
+
 
 Options:
   --version  Show version number                                       [boolean]

--- a/test/system/__snapshots__/generate-org-data.test.ts.snap
+++ b/test/system/__snapshots__/generate-org-data.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`\`snyk-api-import orgs:data <...>\` Generates orgs data as expected 1`] = `"Found 9 org(s). Written the data to file: group-hello-github-com-orgs.json"`;
+
+exports[`\`snyk-api-import orgs:data <...>\` Shows error when missing groupId 1`] = `
+[Error: Command failed: node ./dist/index.js orgs:data --source=github
+index.js orgs:data
+
+Generate data required for Orgs to be created via API by mirroring a given
+source.
+
+
+Options:
+  --version            Show version number                             [boolean]
+  --help               Show help                                       [boolean]
+  --sourceOrgPublicId
+  --groupId            Public id of the group in Snyk (available on group
+                       settings)                                      [required]
+  --source             The source of the targets to be imported e.g. Github
+                              [required] [choices: "github"] [default: "github"]
+
+Missing required argument: groupId
+]
+`;
+
+exports[`\`snyk-api-import orgs:data <...>\` Shows help text as expected 1`] = `
+"index.js orgs:data
+
+Generate data required for Orgs to be created via API by mirroring a given
+source.
+
+
+Options:
+  --version            Show version number                             [boolean]
+  --help               Show help                                       [boolean]
+  --sourceOrgPublicId
+  --groupId            Public id of the group in Snyk (available on group
+                       settings)                                      [required]
+  --source             The source of the targets to be imported e.g. Github
+                              [required] [choices: \\"github\\"] [default: \\"github\\"]"
+`;

--- a/test/system/generate-org-data.test.ts
+++ b/test/system/generate-org-data.test.ts
@@ -1,0 +1,50 @@
+import { exec } from 'child_process';
+import { sep } from 'path';
+import { deleteFiles } from '../delete-files';
+const main = './dist/index.js'.replace(/\//g, sep);
+
+describe('`snyk-api-import orgs:data <...>`', () => {
+  const OLD_ENV = process.env;
+  process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
+  process.env.SNYK_LOG_PATH = __dirname;
+
+  afterAll(async () => {
+    process.env = { ...OLD_ENV };
+  });
+  it('Shows help text as expected', async (done) => {
+    return exec(`node ${main} orgs:data help`, (err, stdout) => {
+      if (err) {
+        throw err;
+      }
+      expect(err).toBeNull();
+      expect(stdout.trim()).toMatchSnapshot();
+      done();
+    });
+  });
+
+  it('Generates orgs data as expected', async (done) => {
+    const groupId = 'hello';
+    return exec(
+      `node ${main} orgs:data --source=github --groupId=${groupId}`,
+      (err, stdout) => {
+        if (err) {
+          throw err;
+        }
+        expect(err).toBeNull();
+        expect(stdout.trim()).toMatchSnapshot();
+        deleteFiles([`group-${groupId}-github-com-orgs.json`]);
+        done();
+      },
+    );
+  });
+  it('Shows error when missing groupId', async (done) => {
+    return exec(
+      `node ${main} orgs:data --source=github`,
+      (err, stdout) => {
+        expect(err).toMatchSnapshot();
+        expect(stdout).toEqual('');
+        done();
+      },
+    );
+  });
+});

--- a/test/system/import.test.ts
+++ b/test/system/import.test.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import * as path from 'path';
-import { deleteLogs } from '../delete-logs';
+import { deleteFiles } from '../delete-files';
 import { generateLogsPaths } from '../generate-log-file-names';
 import { deleteTestProjects } from '../delete-test-projects';
 import { Project } from '../../src/lib/types';
@@ -15,7 +15,7 @@ describe('`snyk-api-import import`', () => {
     await deleteTestProjects(ORG_ID, discoveredProjects);
   });
   afterEach(async () => {
-    deleteLogs(logs);
+    deleteFiles(logs);
   });
   it('Import is default command', async (done) => {
     const testRoot = __dirname + '/fixtures/single-project';


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

- Provide a utility to help generate mirror data for Github orgs
to be mirrored in Snyk.
- re-arrange the docs as they are now growing quite a bit
