### PR TITLE
feat: log full import job status & test empty repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log
 dist
 .DS_Store
 *.log
+*import-job-results.json
 package-lock.json
 yarn.lock
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ By default the `import` command will run if no command specified.
 - `help` - show help & all available commands and their options
 - `orgs:data` - generate data required to create Orgs via API.
 - `import` - kick off a an API powered import of repos/targets into existing Snyk orgs defined in [import configuration file](#to-kick-off-an-import).
+The logs can be explored using [Bunyan CLI](http://trentm.com/node-bunyan/bunyan.1.html)
 
 # Table of Contents
 - Utilities

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,3 +5,4 @@ export const FAILED_POLLS_LOG_NAME = 'failed-polls.log';
 export const IMPORT_JOBS_LOG_NAME = 'import-jobs.log';
 export const IMPORTED_PROJECTS_LOG_NAME = 'imported-projects.log';
 export const IMPORTED_BATCHES_LOG_NAME = 'imported-batches.log';
+export const IMPORT_JOB_RESULTS = 'import-job-results.json';

--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -1,5 +1,6 @@
 import 'source-map-support/register';
 import * as pMap from 'p-map';
+import * as path from 'path';
 import * as debugLib from 'debug';
 import { requestsManager } from 'snyk-request-manager';
 import * as _ from 'lodash';
@@ -29,6 +30,7 @@ export async function importTarget(
   orgId: string;
   integrationId: string;
 }> {
+  const logPath = loggingPath || getLoggingPath();
   getApiToken();
   debug('Importing:', JSON.stringify({ orgId, integrationId, target }));
 
@@ -104,7 +106,10 @@ export async function importTarget(
         target,
       )}.\nERROR name: ${
         error.name
-      } msg: ${errorMessage}. See more information in logs located at ${loggingPath}/${orgId}/*.${FAILED_LOG_NAME} or re-start in DEBUG mode.`,
+      } msg: ${errorMessage}. See more information in logs located at ${path.join(
+        logPath,
+        orgId,
+      )}.${FAILED_LOG_NAME} or re-start in DEBUG mode.`,
     );
     throw err;
   }
@@ -146,7 +151,7 @@ export async function importTargets(
         );
         if (failed % concurrentImports === 0) {
           console.error(
-            `Every import in this batch failed, stopping as this is unexpected! Please check if everything is configured ok and review the logs located at ${loggingPath}. If everything looks OK re-start the import, previously imported targets will be skipped.`,
+            `Every import in this batch failed, stopping as this is unexpected! Please check if everything is configured ok and review the logs located at ${loggingPath}/*. If everything looks OK re-start the import, previously imported targets will be skipped.`,
           );
           // die immediately
           return process.exit(1);

--- a/src/log-job-result.ts
+++ b/src/log-job-result.ts
@@ -1,0 +1,27 @@
+import * as bunyan from 'bunyan';
+import { IMPORT_JOB_RESULTS } from './common';
+
+import { getLoggingPath } from './lib/get-logging-path';
+import { PollImportResponse } from './lib/types';
+
+export async function logJobResult(
+  locationUrl: string,
+  data: PollImportResponse,
+  loggingPath: string = getLoggingPath(),
+): Promise<void> {
+  try {
+    const log = bunyan.createLogger({
+      name: 'snyk:import-projects-script',
+      level: 'info',
+      streams: [
+        {
+          level: 'info',
+          path: `${loggingPath}/${IMPORT_JOB_RESULTS}`,
+        },
+      ],
+    });
+    log.info({ locationUrl, ...data }, 'Import job result');
+  } catch (e) {
+    // do nothing
+  }
+}

--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -66,7 +66,9 @@ export async function importProjects(
     throw new Error(`Failed to parse targets from ${fileName}`);
   }
   const dateNow = new Date(Date.now());
-  console.log(`Loaded ${targets.length} target(s) to import ${dateNow.toUTCString()}`);
+  console.log(
+    `Loaded ${targets.length} target(s) to import ${dateNow.toUTCString()}`,
+  );
   const concurrentTargets = getConcurrentImportsNumber();
   const projects: Project[] = [];
   const filteredTargets = await filterOutImportedTargets(targets, loggingPath);
@@ -101,8 +103,13 @@ export async function importProjects(
       skippedTargets > 0 ? `(skipped ${skippedTargets})` : ''
     }`;
     logImportedBatch(batchProgressMessages);
-    const pollingUrlsAndContext = await importTargets(requestManager, batch, loggingPath);
-    projects.push(...(await pollImportUrls(requestManager, pollingUrlsAndContext)));
+    const pollingUrlsAndContext = await importTargets(
+      requestManager,
+      batch,
+      loggingPath,
+    );
+    const res = await pollImportUrls(requestManager, pollingUrlsAndContext);
+    projects.push(...res.projects);
   }
   return { projects, skippedTargets, filteredTargets, targets };
 }

--- a/test/generate-log-file-names.ts
+++ b/test/generate-log-file-names.ts
@@ -7,6 +7,7 @@ import {
   IMPORT_JOBS_LOG_NAME,
   IMPORTED_PROJECTS_LOG_NAME,
   IMPORTED_BATCHES_LOG_NAME,
+  IMPORT_JOB_RESULTS,
 } from '../src/common';
 
 export function generateLogsPaths(
@@ -19,15 +20,31 @@ export function generateLogsPaths(
   importJobIdsLogsPath: string;
   importedProjectsLogPath: string;
   importedBatchesLogPath: string;
+  importJobsLogPath: string;
 } {
   process.env.SNYK_LOG_PATH = logPath;
   const importLogPath = path.resolve(logPath, IMPORT_LOG_NAME);
-  const failedImportLogPath = path.resolve(logPath, `${orgId}.${FAILED_LOG_NAME}`);
-  const failedProjectsLogPath = path.resolve(logPath, `${orgId}.${FAILED_PROJECTS_LOG_NAME}`);
-  const importJobIdsLogsPath = path.resolve(logPath, `${orgId}.${IMPORT_JOBS_LOG_NAME}`);
-  const importedProjectsLogPath = path.resolve(logPath, `${orgId}.${IMPORTED_PROJECTS_LOG_NAME}`);
-  const importedBatchesLogPath = path.resolve(logPath, IMPORTED_BATCHES_LOG_NAME);
-
+  const failedImportLogPath = path.resolve(
+    logPath,
+    `${orgId}.${FAILED_LOG_NAME}`,
+  );
+  const failedProjectsLogPath = path.resolve(
+    logPath,
+    `${orgId}.${FAILED_PROJECTS_LOG_NAME}`,
+  );
+  const importJobIdsLogsPath = path.resolve(
+    logPath,
+    `${orgId}.${IMPORT_JOBS_LOG_NAME}`,
+  );
+  const importedProjectsLogPath = path.resolve(
+    logPath,
+    `${orgId}.${IMPORTED_PROJECTS_LOG_NAME}`,
+  );
+  const importedBatchesLogPath = path.resolve(
+    logPath,
+    IMPORTED_BATCHES_LOG_NAME,
+  );
+  const importJobsLogPath = path.resolve(logPath, IMPORT_JOB_RESULTS);
   return {
     importLogPath,
     failedImportLogPath,
@@ -35,5 +52,6 @@ export function generateLogsPaths(
     importJobIdsLogsPath,
     importedProjectsLogPath,
     importedBatchesLogPath,
+    importJobsLogPath,
   };
 }

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -40,7 +40,7 @@ describe('Single target', () => {
       },
     );
     expect(pollingUrl).not.toBeNull();
-    const projects = await pollImportUrl(requestManager, pollingUrl);
+    const { projects } = await pollImportUrl(requestManager, pollingUrl);
     expect(projects[0]).toMatchObject({
       projectUrl: expect.any(String),
       success: true,
@@ -89,7 +89,7 @@ describe('Multiple targets', () => {
       },
     ]);
     expect(pollingUrls.length >= 1).toBeTruthy();
-    const projects = await pollImportUrls(requestManager, pollingUrls);
+    const { projects } = await pollImportUrls(requestManager, pollingUrls);
     // at least one job successfully finished
     expect(projects[0]).toMatchObject({
       projectUrl: expect.any(String),

--- a/test/scripts/fixtures/empty-target/import-projects.json
+++ b/test/scripts/fixtures/empty-target/import-projects.json
@@ -1,0 +1,13 @@
+{
+  "targets": [
+    {
+      "orgId": "f0125d9b-271a-4b50-ad23-80e12575a1bf",
+      "integrationId": "c4de291b-e083-4c43-a72c-113463e0d268",
+      "target": {
+        "name": "empty-repo",
+        "owner": "snyk-fixtures",
+        "branch": "master"
+      }
+    }
+  ]
+}

--- a/test/scripts/fixtures/no-supported-manifests/import-projects.json
+++ b/test/scripts/fixtures/no-supported-manifests/import-projects.json
@@ -1,0 +1,13 @@
+{
+  "targets": [
+    {
+      "orgId": "f0125d9b-271a-4b50-ad23-80e12575a1bf",
+      "integrationId": "c4de291b-e083-4c43-a72c-113463e0d268",
+      "target": {
+        "name": "no-supported-manifests",
+        "owner": "snyk-fixtures",
+        "branch": "master"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

### What this does
- Log the entire response on completion of a job
- Add a test for processing an empty repo to show expected behaviour (import complete with no projects returned)
