### PR TITLE
feat: support github enterprise with github.com being a default

### DIFF
--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -6,10 +6,14 @@ It is recommended to have as many Organizations in Snyk as you have in the sourc
 
 ## `orgs:data`
 
-### Github.com
+### Github.com / Github Enterprise
 1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GH_TOKEN=your_personal_access_token`
 2. Run the command to generate Org data:
+  **Github.com:**
   `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id>`
+  **Github Enterprise:**
+  `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id> -- sourceUrl=https://ghe.custom.github.com/`
+
 3. Use the generated data to feed into Snyk [Orgs API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) to generate the organizations within a group.
 
 

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -20,6 +20,11 @@ export const builder = {
     default: undefined,
     desc: 'Public id of the group in Snyk (available on group settings)',
   },
+  sourceUrl: {
+    required: false,
+    default: undefined,
+    desc: 'Custom base url for the source API that can list organizations (e.g. Github Enterprise url)',
+  },
   source: {
     required: true,
     default: Sources.GITHUB,
@@ -36,16 +41,18 @@ export async function handler(argv: {
   source: Sources;
   groupId: string;
   sourceOrgPublicId?: string;
+  sourceUrl?: string;
 }): Promise<void> {
   try {
     getLoggingPath();
-    const { source, sourceOrgPublicId, groupId } = argv;
+    const { source, sourceOrgPublicId, groupId, sourceUrl } = argv;
     debug('ℹ️  Options: ' + JSON.stringify(argv));
 
     const res = await generateOrgImportDataFile(
       source,
       groupId,
       sourceOrgPublicId,
+      sourceUrl,
     );
     const orgsMessage =
       res.orgs.length > 0

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -6,8 +6,8 @@ export enum Sources {
   GITHUB = 'github',
 }
 
-async function githubOrganizations(): Promise<{ name: string }[]> {
-  const ghOrgs: GithubOrgData[] = await listGithubOrgs();
+async function githubOrganizations(sourceUrl?: string): Promise<{ name: string }[]> {
+  const ghOrgs: GithubOrgData[] = await listGithubOrgs(sourceUrl);
   return ghOrgs;
 }
 
@@ -19,14 +19,15 @@ export async function generateOrgImportDataFile(
   source: Sources,
   groupId: string,
   sourceOrgId?: string,
+  sourceUrl?: string,
 ): Promise<{ orgs: CreateOrgData[]; fileName: string }> {
   const orgData: CreateOrgData[] = [];
 
-  const toplevelEntities = await sourceGenerators[source]();
+  const topLevelEntities = await sourceGenerators[source](sourceUrl);
 
-  for (const org in toplevelEntities) {
+  for (const org in topLevelEntities) {
     const data: CreateOrgData = {
-      name: toplevelEntities[org].name,
+      name: topLevelEntities[org].name,
       groupId,
     };
     if (sourceOrgId) {
@@ -34,7 +35,7 @@ export async function generateOrgImportDataFile(
     }
     orgData.push(data);
   }
-  const fileName = `group-${groupId}-github-com-orgs.json`;
+  const fileName = `group-${groupId}-${sourceUrl? 'github-enterprise' : 'github-com'}-orgs.json`;
   await writeFile(fileName, ({
     orgs: orgData,
   } as unknown) as JSON);

--- a/src/scripts/github/list-orgs.ts
+++ b/src/scripts/github/list-orgs.ts
@@ -5,14 +5,15 @@ export interface GithubOrgData {
   id: number;
   url: string;
 }
-export async function listGithubOrgs(): Promise<GithubOrgData[]> {
+export async function listGithubOrgs(baseUrl = 'https://api.github.com'): Promise<GithubOrgData[]> {
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
     throw new Error(
       `Please set the GITHUB_TOKEN e.g. export GITHUB_TOKEN='mypersonalaccesstoken123'`,
     );
   }
-  const octokit = new Octokit({ auth: githubToken });
+
+  const octokit = new Octokit({ baseUrl, auth: githubToken });
   const res = await octokit.orgs.listForAuthenticatedUser();
   const orgsData = res && res.data;
 

--- a/src/scripts/github/list-orgs.ts
+++ b/src/scripts/github/list-orgs.ts
@@ -1,18 +1,21 @@
 import { Octokit } from '@octokit/rest';
+import { url } from 'inspector';
 
 export interface GithubOrgData {
   name: string;
   id: number;
   url: string;
 }
-export async function listGithubOrgs(baseUrl = 'https://api.github.com'): Promise<GithubOrgData[]> {
+export async function listGithubOrgs(host?: string): Promise<GithubOrgData[]> {
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
     throw new Error(
       `Please set the GITHUB_TOKEN e.g. export GITHUB_TOKEN='mypersonalaccesstoken123'`,
     );
   }
-
+  const baseUrl = host
+    ? new URL('/api/v3', host).toString()
+    : 'https://api.github.com';
   const octokit = new Octokit({ baseUrl, auth: githubToken });
   const res = await octokit.orgs.listForAuthenticatedUser();
   const orgsData = res && res.data;

--- a/test/scripts/github.test.ts
+++ b/test/scripts/github.test.ts
@@ -1,23 +1,35 @@
-import { listGithubOrgs } from "../../src/scripts/github/list-orgs";
-import { listGithubRepos } from "../../src/scripts/github/list-repos";
+import { listGithubOrgs } from '../../src/scripts/github/list-orgs';
+import { listGithubRepos } from '../../src/scripts/github/list-repos';
 
 describe('listGithubOrgs script', () => {
   const OLD_ENV = process.env;
-  const GITHUB_ORG_NAME = process.env.TEST_GH_ORG_NAME;
-  process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
 
-  afterAll(async () => {
+  afterEach(async () => {
     process.env = { ...OLD_ENV };
   });
   it('list orgs', async () => {
+    process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
     const orgs = await listGithubOrgs();
     expect(orgs[0]).toEqual({
       name: expect.any(String),
       id: expect.any(Number),
-      url: expect.any(String)
+      url: expect.any(String),
+    });
+  });
+  it('list orgs GHE', async () => {
+    process.env.GITHUB_TOKEN = process.env.TEST_GHE_TOKEN;
+    const GHE_URL = process.env.TEST_GHE_URL;
+    const orgs = await listGithubOrgs(GHE_URL);
+    expect(orgs[0]).toEqual({
+      name: expect.any(String),
+      id: expect.any(Number),
+      url: expect.any(String),
     });
   });
   it('list repos', async () => {
+    const GITHUB_ORG_NAME = process.env.TEST_GH_ORG_NAME;
+    process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
+
     const orgs = await listGithubRepos(GITHUB_ORG_NAME as string);
     expect(orgs[0]).toEqual({
       name: expect.any(String),

--- a/test/system/__snapshots__/generate-org-data.test.ts.snap
+++ b/test/system/__snapshots__/generate-org-data.test.ts.snap
@@ -16,6 +16,8 @@ Options:
   --sourceOrgPublicId
   --groupId            Public id of the group in Snyk (available on group
                        settings)                                      [required]
+  --sourceUrl          Custom base url for the source API that can list
+                       organizations (e.g. Github Enterprise url)
   --source             The source of the targets to be imported e.g. Github
                               [required] [choices: "github"] [default: "github"]
 
@@ -36,6 +38,8 @@ Options:
   --sourceOrgPublicId
   --groupId            Public id of the group in Snyk (available on group
                        settings)                                      [required]
+  --sourceUrl          Custom base url for the source API that can list
+                       organizations (e.g. Github Enterprise url)
   --source             The source of the targets to be imported e.g. Github
                               [required] [choices: \\"github\\"] [default: \\"github\\"]"
 `;


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Set a default github.com url for github API calls