### PR TITLE
fix: imported project message to reflect "import"

### DIFF
--- a/src/log-imported-projects.ts
+++ b/src/log-imported-projects.ts
@@ -28,11 +28,11 @@ export async function logImportedProjects(
       });
       debug(
         { orgId, locationUrl, projectId, ...project },
-        'Error importing project',
+        'Imported project',
       );
       log.info(
         { orgId, locationUrl, projectId, ...project },
-        'Error importing project',
+        'Imported project',
       );
     });
   } catch (e) {

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -48,7 +48,7 @@ describe('Single target', () => {
     });
     // cleanup
     discoveredProjects.push(...projects);
-  }, 30000000);
+  }, 240000);
   afterAll(async () => {
     await deleteTestProjects(ORG_ID, discoveredProjects);
     await deleteFiles(logs);
@@ -98,7 +98,7 @@ describe('Multiple targets', () => {
     });
     // cleanup
     discoveredProjects.push(...projects);
-  }, 30000000);
+  }, 240000);
   afterAll(async () => {
     await deleteTestProjects(ORG_ID, discoveredProjects);
     await deleteFiles(logs);

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -46,7 +46,7 @@ describe('Import projects script', () => {
       `"target":{"name":"ruby-with-versions","owner":"snyk-fixtures","branch":"master"}`,
     );
     discoveredProjects.push(...projects);
-  }, 30000000);
+  }, 240000);
 });
 
 describe('Import skips previously imported', () => {
@@ -73,7 +73,7 @@ describe('Import skips previously imported', () => {
     await new Promise((r) => setTimeout(r, 1000));
     const logFile = fs.readFileSync(logFiles.importLogPath, 'utf8');
     expect(logFile).toMatch('composer-with-vulns:snyk-fixtures:master');
-  }, 30000000);
+  }, 240000);
 });
 
 describe('Skips & logs issues', () => {
@@ -147,7 +147,7 @@ describe('Skips & logs issues', () => {
     } catch (e) {
       // ignore
     }
-  }, 30000000);
+  }, 240000);
   it('Logs failed projects', async () => {
     const logRoot = __dirname + '/fixtures/projects-with-errors/';
     const logFiles = generateLogsPaths(logRoot, ORG_ID);

--- a/test/scripts/polling.test.ts
+++ b/test/scripts/polling.test.ts
@@ -50,5 +50,5 @@ describe('Logs failed polls', () => {
     await new Promise((r) => setTimeout(r, 300));
     const failedLog = fs.readFileSync(failedPollsLogName, 'utf8');
     expect(failedLog).toMatch(`"level":50,"orgId":"ORG-ID","locationUrl":"https://app.snyk.io/api/v1/org/ORG-ID/integrations/INTEGRATION-ID/import/IMPORT-ID","errorMessage":{"statusCode":500,"error":{"message":"Error calling Snyk api"}},"msg":"Failed to poll url"`)
-  }, 30000000);
+  }, 240000);
 });

--- a/test/system/import.test.ts
+++ b/test/system/import.test.ts
@@ -47,7 +47,7 @@ Check the logs for any failures located at:`);
         done();
       },
     );
-  }, 30000000);
+  }, 240000);
   it('import triggers the API import', async (done) => {
     const testRoot = __dirname + '/fixtures';
     const logFiles = generateLogsPaths(testRoot, ORG_ID);
@@ -79,5 +79,5 @@ Check the logs for any failures located at:`);
         done();
       },
     );
-  }, 30000000);
+  }, 240000);
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
The log message was accidentally saying the opposite on successful project import