### PR TITLE
feat: support GHE base url when lising repos

### DIFF
--- a/src/scripts/github/github-base-url.ts
+++ b/src/scripts/github/github-base-url.ts
@@ -1,0 +1,5 @@
+export function getGithubBaseUrl(host?: string): string {
+  return host
+    ? new URL('/api/v3', host).toString()
+    : 'https://api.github.com';
+}

--- a/src/scripts/github/list-orgs.ts
+++ b/src/scripts/github/list-orgs.ts
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import { url } from 'inspector';
+import { getGithubBaseUrl } from './github-base-url';
 
 export interface GithubOrgData {
   name: string;
@@ -13,9 +14,7 @@ export async function listGithubOrgs(host?: string): Promise<GithubOrgData[]> {
       `Please set the GITHUB_TOKEN e.g. export GITHUB_TOKEN='mypersonalaccesstoken123'`,
     );
   }
-  const baseUrl = host
-    ? new URL('/api/v3', host).toString()
-    : 'https://api.github.com';
+  const baseUrl = getGithubBaseUrl(host);
   const octokit = new Octokit({ baseUrl, auth: githubToken });
   const res = await octokit.orgs.listForAuthenticatedUser();
   const orgsData = res && res.data;

--- a/src/scripts/github/list-repos.ts
+++ b/src/scripts/github/list-repos.ts
@@ -1,4 +1,5 @@
 import { Octokit } from '@octokit/rest';
+import { getGithubBaseUrl } from './github-base-url';
 
 interface RepoData {
   fork: boolean;
@@ -6,14 +7,15 @@ interface RepoData {
   owner: string;
   name: string;
 }
-export async function listGithubRepos(orgName: string): Promise<RepoData[]> {
+export async function listGithubRepos(orgName: string, host?: string): Promise<RepoData[]> {
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
     throw new Error(
       `Please set the GITHUB_TOKEN e.g. export GITHUB_TOKEN='mypersonalaccesstoken123'`,
     );
   }
-  const octokit = new Octokit({ auth: githubToken });
+  const baseUrl = getGithubBaseUrl(host);
+  const octokit = new Octokit({ baseUrl, auth: githubToken });
   const res = await octokit.repos.listForOrg({
     org: orgName,
   });

--- a/test/scripts/github.test.ts
+++ b/test/scripts/github.test.ts
@@ -38,4 +38,18 @@ describe('listGithubOrgs script', () => {
       fork: expect.any(Boolean),
     });
   });
+
+  it('list GHE repos', async () => {
+    const GITHUB_ORG_NAME = process.env.TEST_GH_ORG_NAME;
+    const GHE_URL = process.env.TEST_GHE_URL;
+    process.env.GITHUB_TOKEN = process.env.TEST_GHE_TOKEN;
+
+    const orgs = await listGithubRepos(GITHUB_ORG_NAME as string, GHE_URL);
+    expect(orgs[0]).toEqual({
+      name: expect.any(String),
+      owner: expect.any(String),
+      branch: expect.any(String),
+      fork: expect.any(Boolean),
+    });
+  });
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Add support for GHE when listing repos too in preparation for generating the import data