### PR TITLE
feat: generate targets import data based on Snyk Org data

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,6 @@ The logs can be explored using [Bunyan CLI](http://trentm.com/node-bunyan/bunyan
 # Table of Contents
 - Utilities
   - [Generating orgs in Snyk](docs/orgs.md)
+  - [Generating import data](docs/import-data.md)
 - [Kicking off an import](docs/import.md)
 - [Contributing](.github/CONTRIBUTING.md)

--- a/docs/import-data.md
+++ b/docs/import-data.md
@@ -1,0 +1,38 @@
+# Creating import targets data for import
+
+This is a util that can help generate the import json data needed t=by the import command.
+
+## `import:data`
+
+### Github.com / Github Enterprise
+1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
+2. You will need to have the orgs data in json as an input to this command to help map Snyk Org IDs and Integration Ids that must be used during import against individual targets to be imported. The following format is required:
+  ```
+  {
+    "orgData": [
+      {
+        "name": "<org_name_in_gh_used_to_list_repos>",
+        "orgId": "<snyk_org_id>",
+        "integrations": {
+          "github": "<snyk_org_integration_id>",
+          "github-enterprise": "<snyk_org_integration_id>
+        },
+      },
+      {...}
+    ]
+  }
+  ```
+   - Github/Github Enterprise orgs can be listed using the [/orgs API](https://docs.github.com/en/free-pro-team@latest/rest/reference/orgs)
+   - Integrations can be listed via [Snyk Orgs API](https://snyk.docs.apiary.io/#reference/integrations/integrations/list)
+   - All org IDs can be found by listing all orgs a group admin belongs to via [Snyk API](https://snyk.docs.apiary.io/#reference/organizations/the-snyk-organization-for-a-request/list-all-the-organizations-a-user-belongs-to)
+
+3. Run the command to generate import data:
+ - **Github.com:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github --integrationType=github`
+ - **Github Enterprise:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise --integrationType=github-enterprise --sourceUrl=https://ghe.custom.com`
+
+4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
+
+
+## Recommendations
+- have [notifications disabled](https://snyk.docs.apiary.io/#reference/organizations/notification-settings/set-notification-settings) for emails etc to avoid receiving import notifications
+- have the [fix PRs and PR checks disabled](https://snyk.docs.apiary.io/#reference/integrations/integration-settings/update) until import is complete to avoid sending extra requests to SCMs (Github/Gitlab/Bitbucket etc)

--- a/src/cmds/import.ts
+++ b/src/cmds/import.ts
@@ -1,4 +1,6 @@
 import * as debugLib from 'debug';
+import * as _ from 'lodash';
+
 const debug = debugLib('snyk:import-projects-script');
 
 import { importProjects } from '../scripts/import-projects';
@@ -22,7 +24,7 @@ export async function handler(): Promise<void> {
     } = await importProjects(importFile);
     const projectsMessage =
       projects.length > 0
-        ? `Imported ${projects.length} project(s)`
+        ? `Imported ${ _.uniqBy(projects, 'projectUrl').length} project(s)`
         : '⚠ No projects imported!';
 
     const targetsMessage = `\nProcessed ${filteredTargets.length} out of a total of ${

--- a/src/cmds/import:data.ts
+++ b/src/cmds/import:data.ts
@@ -1,0 +1,83 @@
+import * as debugLib from 'debug';
+const debug = debugLib('snyk:generate-data-script');
+
+import { getLoggingPath } from '../lib/get-logging-path';
+import { CreatedOrg } from '../lib/types';
+import { loadFile } from '../load-file';
+import { Sources } from '../scripts/generate-org-data';
+import {
+  generateTargetsImportDataFile,
+  SupportedIntegrationTypes,
+} from '../scripts/generate-targets-data';
+
+export const command = ['import:data'];
+export const desc =
+  'Generate data required for targets to be imported via API to create Snyk projects.\n';
+export const builder = {
+  orgsData: {
+    required: true,
+    default: undefined,
+    desc: 'Path to orgs data file generated with "orgs:data" command',
+  },
+  source: {
+    required: true,
+    default: Sources.GITHUB,
+    choices: [Sources.GITHUB],
+    desc:
+      'The source of the targets to be imported e.g. Github. This will be used to make an API call to list all available entities per org',
+  },
+  integrationType: {
+    required: true,
+    default: undefined,
+    choices: [Object.values(SupportedIntegrationTypes)],
+    desc:
+      'The configured integration type on the created Snyk Org to use for generating import targets data. Applies to all targets.',
+  },
+};
+
+const entityName = {
+  github: 'repo',
+};
+
+export async function handler(argv: {
+  source: Sources;
+  orgsData: string;
+  integrationType: SupportedIntegrationTypes;
+}): Promise<void> {
+  try {
+    getLoggingPath();
+    const { source, orgsData, integrationType } = argv;
+    debug('ℹ️  Options: ' + JSON.stringify(argv));
+
+    const content = await loadFile(orgsData);
+    const orgsDataJson: CreatedOrg[] = [];
+    try {
+      orgsDataJson.push(...JSON.parse(content).orgs);
+    } catch (e) {
+      throw new Error(
+        `Failed to parse orgs from ${orgsData}. ERROR: ${e.message}`,
+      );
+    }
+    if (orgsDataJson.length === 0) {
+      throw new Error(
+        `No orgs could be loaded from ${orgsData}.`,
+      );
+    }
+    const res = await generateTargetsImportDataFile(
+      source,
+      orgsDataJson,
+      integrationType,
+    );
+    const targetsMessage =
+      res.targets.length > 0
+        ? `Found ${res.targets.length} ${entityName[source]}(s). Written the data to file: ${res.fileName}`
+        : `⚠ No import ${entityName[source]}(s) data generated!`;
+
+    console.log(targetsMessage);
+  } catch (e) {
+    debug('Failed to generate data.\n' + e);
+    console.error(
+      `ERROR! Failed to generate data. Try running with \`DEBUG=snyk* <command> for more info\`.\nERROR: ${e}`,
+    );
+  }
+}

--- a/src/lib/poll-import/index.ts
+++ b/src/lib/poll-import/index.ts
@@ -98,9 +98,9 @@ export async function pollImportUrls(
         );
         console.log(
           `Discovered ${
-            projects.length
+            _.uniqBy(projects, 'projectUrl').length
           } projects from import job id: ${importJobId}${
-            failedProjects.length
+            _.uniqBy(projects, 'projectUrl').length
               ? `. ${failedProjects.length} project(s) failed to finish importing.`
               : ''
           }`,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,17 @@ export interface ImportTarget {
   exclusionGlobs?: string;
 }
 
+export interface CreatedOrg {
+  name: string;
+  created?: string;
+  integrations: {
+    [name: string]: string;
+  };
+  orgId: string;
+  groupId: string;
+  origName: string; // name requested to be created
+  sourceOrgId?: string;
+}
 export interface Target {
   name?: string; // Gitlab, GitHub, GH Enterprise, Bitbucket Cloud and Azure Repos, Bitbucket Server, Azure Container Registry, Elastic Container Registry, Artifactory Container Registry, Docker Hub
   appId?: string; // Heroku, CloudFoundry, Pivotal & IBM Cloud

--- a/src/scripts/create-orgs.ts
+++ b/src/scripts/create-orgs.ts
@@ -36,7 +36,7 @@ export async function logCreatedOrg(
   }
 }
 
-interface CreatedOrg extends CreatedOrgResponse {
+interface SnykOrgData extends CreatedOrgResponse {
   integrations: {
     [name: string]: string;
   };
@@ -57,7 +57,7 @@ export async function createOrgs(
     userAgentPrefix: 'snyk-api-import',
   });
   debug(`Loaded ${orgsData.length} orgs to create ${Date.now()}`);
-  const createdOrgs: CreatedOrg[] = [];
+  const createdOrgs: SnykOrgData[] = [];
   orgsData.forEach(async (orgData) => {
     try {
       const { groupId, name, sourceOrgId } = orgData;

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -15,7 +15,7 @@ async function githubEnterpriseOrganizations(sourceUrl?: string): Promise<{ name
   return ghOrgs;
 }
 
-async function githubOrganizations(sourceUrl?: string): Promise<{ name: string }[]> {
+async function githubOrganizations(): Promise<{ name: string }[]> {
   const ghOrgs: GithubOrgData[] = await listGithubOrgs();
   return ghOrgs;
 }

--- a/src/scripts/generate-targets-data.ts
+++ b/src/scripts/generate-targets-data.ts
@@ -1,0 +1,95 @@
+import * as _ from 'lodash';
+
+import { CreatedOrg, ImportTarget } from '../lib/types';
+import { writeFile } from '../write-file';
+import { GithubRepoData, listGithubRepos } from './github';
+
+export enum Sources {
+  GITHUB = 'github',
+}
+
+async function githubRepos(orgName: string): Promise<GithubRepoData[]> {
+  const ghRepos: GithubRepoData[] = await listGithubRepos(orgName);
+  return ghRepos;
+}
+
+const sourceGenerators = {
+  [Sources.GITHUB]: githubRepos,
+};
+
+export enum SupportedIntegrationTypes {
+  GITHUB = 'github',
+  GHE = 'github-enterprise',
+}
+
+function validateRequiredOrgData(
+  name: string,
+  integrations: {
+    [name: string]: string;
+  },
+  orgId: string,
+): void {
+  if (!name) {
+    throw new Error('Org field:`name` is required');
+  }
+  if (!orgId) {
+    throw new Error('Org field: `orgId` is required');
+  }
+  if (!integrations || Object.keys(integrations).length < 1) {
+    throw new Error(
+      'Org field: `integrations` is required and must have at least 1 integration',
+    );
+  }
+
+  if (
+    _.intersection(
+      Object.keys(integrations),
+      Object.values(SupportedIntegrationTypes),
+    ).length === 0
+  ) {
+    throw new Error(
+      'At least one supported integration is expected in `integrations` field.' +
+        `Supported integrations are: ${Object.values(
+          SupportedIntegrationTypes,
+        ).join(',')}`,
+    );
+  }
+}
+
+export async function generateTargetsImportDataFile(
+  source: Sources,
+  orgsData: CreatedOrg[],
+  integrationType: SupportedIntegrationTypes,
+): Promise<{ targets: ImportTarget[]; fileName: string }> {
+  const targetsData: ImportTarget[] = [];
+
+  const orgsDataUnique = _.uniqBy(orgsData, 'orgId');
+  for (const topLevelEntity of orgsDataUnique) {
+    const { name, integrations, orgId } = topLevelEntity;
+    try {
+      validateRequiredOrgData(name, integrations, orgId);
+      const entities = await sourceGenerators[source](topLevelEntity.name);
+      entities.forEach((entity) => {
+        targetsData.push({
+          target: entity,
+          integrationId: integrations[integrationType],
+          orgId,
+        });
+      });
+    } catch (e) {
+      console.error(
+        `Failed to generate import data for org: ${name} (${orgId}). Error: ${e.message}`,
+      );
+    }
+  }
+  if (targetsData.length === 0) {
+    throw new Error(
+      'No targets could be generated. Check the error output & try again.',
+    );
+  }
+  const fileName = `${source}-import-targets.json`;
+  await writeFile(fileName, ({
+    targets: targetsData,
+  } as unknown) as JSON);
+  return { targets: targetsData, fileName };
+}

--- a/src/scripts/github/index.ts
+++ b/src/scripts/github/index.ts
@@ -1,1 +1,2 @@
 export * from './list-orgs';
+export * from './list-repos';

--- a/src/scripts/github/list-orgs.ts
+++ b/src/scripts/github/list-orgs.ts
@@ -49,6 +49,7 @@ async function fetchAllOrgs(
   let hasMorePages = true;
   while (hasMorePages) {
     currentPage = currentPage + 1;
+    debug(`Fetching page ${currentPage}`);
     const { orgs, hasNextPage } = await fetchOrgsForPage(octokit, currentPage);
     orgsData.push(...orgs);
     hasMorePages = hasNextPage;
@@ -66,6 +67,7 @@ export async function listGithubOrgs(host?: string): Promise<GithubOrgData[]> {
 
   const baseUrl = getGithubBaseUrl(host);
   const octokit: Octokit = new Octokit({ baseUrl, auth: githubToken });
+  debug('Fetching all Github orgs data');
 
   const orgs = await fetchAllOrgs(octokit);
 

--- a/src/scripts/github/list-repos.ts
+++ b/src/scripts/github/list-repos.ts
@@ -1,5 +1,9 @@
 import { Octokit } from '@octokit/rest';
+import * as debugLib from 'debug';
+
 import { getGithubBaseUrl } from './github-base-url';
+
+const debug = debugLib('snyk:list-repos-script');
 
 export interface GithubRepoData {
   fork: boolean;
@@ -7,6 +11,60 @@ export interface GithubRepoData {
   owner: string;
   name: string;
 }
+
+async function fetchReposForPage(
+  octokit: Octokit,
+  orgName: string,
+  pageNumber = 1,
+): Promise<{
+  repos: GithubRepoData[];
+  hasNextPage: boolean;
+}> {
+  const repoData: GithubRepoData[] = [];
+  const params = {
+    per_page: 100,
+    page: pageNumber,
+    org: orgName,
+  };
+  const res = await octokit.repos.listForOrg(params);
+  const repos = res && res.data;
+  let hasNextPage;
+  if (repos.length) {
+    hasNextPage = true;
+    repoData.push(
+      ...repos
+        .filter((repo) => !repo.archived)
+        .map((repo) => ({
+          fork: repo.fork,
+          name: repo.name,
+          owner: repo.owner.login,
+          branch: repo.default_branch,
+        })),
+    );
+  } else {
+    hasNextPage = false;
+  }
+  return { repos: repoData, hasNextPage};
+}
+
+async function fetchAllRepos(
+  octokit: Octokit,
+  orgName: string,
+  page = 0,
+): Promise<GithubRepoData[]> {
+  const repoData: GithubRepoData[] = [];
+  let currentPage = page;
+  let hasMorePages = true;
+  while (hasMorePages) {
+    currentPage = currentPage + 1;
+    debug(`Fetching page: ${currentPage}`)
+    const { repos, hasNextPage } = await fetchReposForPage(octokit, orgName, currentPage);
+    hasMorePages = hasNextPage;
+    repoData.push(...repos);
+  }
+  return repoData;
+}
+
 export async function listGithubRepos(
   orgName: string,
   host?: string,
@@ -18,22 +76,9 @@ export async function listGithubRepos(
     );
   }
   const baseUrl = getGithubBaseUrl(host);
-  const octokit = new Octokit({ baseUrl, auth: githubToken });
-  const res = await octokit.repos.listForOrg({
-    org: orgName,
-  });
-  const repoData = res && res.data;
+  const octokit: Octokit = new Octokit({ baseUrl, auth: githubToken });
+  debug(`Fetching all repos data for org: ${orgName}`)
+  const repos = await fetchAllRepos(octokit, orgName);
 
-  if (!repoData.length) {
-    return [];
-  }
-  const repos: GithubRepoData[] = repoData
-    .filter((repo) => !repo.archived)
-    .map((repo) => ({
-      fork: repo.fork,
-      name: repo.name,
-      owner: repo.owner.login,
-      branch: repo.default_branch,
-    }));
   return repos;
 }

--- a/src/scripts/github/list-repos.ts
+++ b/src/scripts/github/list-repos.ts
@@ -1,13 +1,16 @@
 import { Octokit } from '@octokit/rest';
 import { getGithubBaseUrl } from './github-base-url';
 
-interface RepoData {
+export interface GithubRepoData {
   fork: boolean;
   branch: string;
   owner: string;
   name: string;
 }
-export async function listGithubRepos(orgName: string, host?: string): Promise<RepoData[]> {
+export async function listGithubRepos(
+  orgName: string,
+  host?: string,
+): Promise<GithubRepoData[]> {
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
     throw new Error(
@@ -24,7 +27,7 @@ export async function listGithubRepos(orgName: string, host?: string): Promise<R
   if (!repoData.length) {
     return [];
   }
-  const repos: RepoData[] = repoData
+  const repos: GithubRepoData[] = repoData
     .filter((repo) => !repo.archived)
     .map((repo) => ({
       fork: repo.fork,

--- a/test/scripts/generate-targets-data.test.ts
+++ b/test/scripts/generate-targets-data.test.ts
@@ -1,0 +1,124 @@
+import * as _ from 'lodash';
+import * as path from 'path';
+import { CreatedOrg } from '../../src/lib/types';
+import { Sources } from '../../src/scripts/generate-org-data';
+import {
+  generateTargetsImportDataFile,
+  SupportedIntegrationTypes,
+} from '../../src/scripts/generate-targets-data';
+import { deleteFiles } from '../delete-files';
+
+describe('generateTargetsImportDataFile Github script', () => {
+  const OLD_ENV = process.env;
+  process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
+  process.env.SNYK_LOG_PATH = __dirname;
+  const filesToDelete: string[] = [];
+  afterEach(async () => {
+    process.env = { ...OLD_ENV };
+    await deleteFiles(filesToDelete);
+  });
+  it('generate Github Orgs data', async () => {
+    filesToDelete.push(path.resolve(__dirname + '/github-import-targets.json'));
+    const orgsData: CreatedOrg[] = [
+      {
+        orgId: 'org-id',
+        name: process.env.TEST_GH_ORG_NAME as string,
+        groupId: 'group-id',
+        origName: process.env.TEST_GH_ORG_NAME as string,
+        integrations: {
+          github: 'github-********-********-********',
+          'github-enterprise': 'github-enterprise-********-********',
+        },
+        sourceOrgId: 'source-org-id',
+      },
+    ];
+
+    const res = await generateTargetsImportDataFile(
+      Sources.GITHUB,
+      orgsData,
+      SupportedIntegrationTypes.GITHUB,
+    );
+    expect(res.fileName).toEqual('github-import-targets.json');
+    expect(res.targets.length > 0).toBeTruthy();
+    expect(res.targets[0]).toEqual({
+      target: {
+        name: expect.any(String),
+        branch: expect.any(String),
+        owner: expect.any(String),
+        fork: expect.any(Boolean),
+      },
+      integrationId: 'github-********-********-********',
+      orgId: 'org-id',
+    });
+  });
+
+  it('generate Github Orgs data', async () => {
+    const orgsData: CreatedOrg[] = [
+      {
+        orgId: process.env.TEST_GH_ORG_NAME as string,
+        name: process.env.TEST_GH_ORG_NAME as string,
+        groupId: 'group-id',
+        origName: process.env.TEST_GH_ORG_NAME as string,
+        integrations: {},
+        sourceOrgId: 'source-org-id',
+      },
+    ];
+
+    expect(
+      generateTargetsImportDataFile(
+        Sources.GITHUB,
+        orgsData,
+        SupportedIntegrationTypes.GITHUB,
+      ),
+    ).rejects.toThrow(
+      'No targets could be generated. Check the error output & try again.',
+    );
+  });
+  it('Duplicate orgs are ignored', async () => {
+    filesToDelete.push(path.resolve(__dirname + '/github-import-targets.json'));
+    const orgsData: CreatedOrg[] = [
+      {
+        orgId: process.env.TEST_GH_ORG_NAME as string,
+        name: process.env.TEST_GH_ORG_NAME as string,
+        groupId: 'group-id',
+        origName: process.env.TEST_GH_ORG_NAME as string,
+        integrations: {
+          github: 'github-********-********-********',
+          'github-enterprise': 'github-enterprise-********-********',
+        },
+        sourceOrgId: 'source-org-id',
+      },
+      // same again!
+      {
+        orgId: process.env.TEST_GH_ORG_NAME as string,
+        name: process.env.TEST_GH_ORG_NAME as string,
+        groupId: 'group-id',
+        origName: process.env.TEST_GH_ORG_NAME as string,
+        integrations: {
+          github: 'github-********-********-********',
+          'github-enterprise': 'github-enterprise-********-********',
+        },
+        sourceOrgId: 'source-org-id',
+      },
+    ];
+
+    const res = await generateTargetsImportDataFile(
+      Sources.GITHUB,
+      orgsData,
+      SupportedIntegrationTypes.GITHUB,
+    );
+    expect(res.fileName).toEqual('github-import-targets.json');
+    expect(res.targets.length > 0).toBeTruthy();
+    expect(_.uniqBy(res.targets, 'target.name')).toBeTruthy();
+    expect(res.targets[0]).toEqual({
+      target: {
+        name: expect.any(String),
+        branch: expect.any(String),
+        owner: expect.any(String),
+        fork: expect.any(Boolean),
+      },
+      integrationId: expect.any(String),
+      orgId: expect.any(String),
+    });
+  });
+});

--- a/test/scripts/generate-targets-data.test.ts
+++ b/test/scripts/generate-targets-data.test.ts
@@ -10,7 +10,6 @@ import { deleteFiles } from '../delete-files';
 
 describe('generateTargetsImportDataFile Github script', () => {
   const OLD_ENV = process.env;
-  process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
   process.env.SNYK_LOG_PATH = __dirname;
   const filesToDelete: string[] = [];
   afterEach(async () => {
@@ -18,6 +17,7 @@ describe('generateTargetsImportDataFile Github script', () => {
     await deleteFiles(filesToDelete);
   });
   it('generate Github Orgs data', async () => {
+    process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
     filesToDelete.push(path.resolve(__dirname + '/github-import-targets.json'));
     const orgsData: CreatedOrg[] = [
       {
@@ -52,7 +52,46 @@ describe('generateTargetsImportDataFile Github script', () => {
     });
   });
 
-  it('generate Github Orgs data', async () => {
+  it('generate Github Enterprise Orgs data', async () => {
+    process.env.GITHUB_TOKEN = process.env.TEST_GHE_TOKEN;
+    const GHE_URL = process.env.TEST_GHE_URL;
+    filesToDelete.push(path.resolve(__dirname + '/github-import-targets.json'));
+    const orgsData: CreatedOrg[] = [
+      {
+        orgId: 'org-id',
+        name: process.env.TEST_GH_ORG_NAME as string,
+        groupId: 'group-id',
+        origName: process.env.TEST_GH_ORG_NAME as string,
+        integrations: {
+          github: 'github-********-********-********',
+          'github-enterprise': 'github-enterprise-********-********',
+        },
+        sourceOrgId: 'source-org-id',
+      },
+    ];
+
+    const res = await generateTargetsImportDataFile(
+      Sources.GHE,
+      orgsData,
+      SupportedIntegrationTypes.GHE,
+      GHE_URL,
+    );
+    expect(res.fileName).toEqual('github-enterprise-import-targets.json');
+    expect(res.targets.length > 0).toBeTruthy();
+    expect(res.targets[0]).toEqual({
+      target: {
+        name: expect.any(String),
+        branch: expect.any(String),
+        owner: expect.any(String),
+        fork: expect.any(Boolean),
+      },
+      integrationId: 'github-enterprise-********-********',
+      orgId: 'org-id',
+    });
+  });
+
+  it('generate Github Orgs data when no integrations are available', async () => {
+    process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
     const orgsData: CreatedOrg[] = [
       {
         orgId: process.env.TEST_GH_ORG_NAME as string,
@@ -75,6 +114,7 @@ describe('generateTargetsImportDataFile Github script', () => {
     );
   });
   it('Duplicate orgs are ignored', async () => {
+    process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
     filesToDelete.push(path.resolve(__dirname + '/github-import-targets.json'));
     const orgsData: CreatedOrg[] = [
       {

--- a/test/system/__snapshots__/basic.test.ts.snap
+++ b/test/system/__snapshots__/basic.test.ts.snap
@@ -6,9 +6,12 @@ exports[`\`snyk-api-import help <...>\` Shows help text as expected 1`] = `
 Kick off API powered import
 
 Commands:
-  index.js import     Kick off API powered import         [default] [aliases: i]
-  index.js orgs:data  Generate data required for Orgs to be created via API by
-                      mirroring a given source.
+  index.js import       Kick off API powered import       [default] [aliases: i]
+  index.js import:data  Generate data required for targets to be imported via
+                        API to create Snyk projects.
+
+  index.js orgs:data    Generate data required for Orgs to be created via API by
+                        mirroring a given source.
 
 
 Options:


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Utility to help generate Import Data from Github & Github Enterpise to be used during `import` command. This is *opinionated* and assumes user wants a *mirror* of their GH / GHE orgs in Snyk with the corresponding repos underneath. 