### PR TITLE
feat: separate github-enterprise as a source type

### DIFF
--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -10,7 +10,7 @@ It is recommended to have as many Organizations in Snyk as you have in the sourc
 1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GH_TOKEN=your_personal_access_token`
 2. Run the command to generate Org data:
  - **Github.com:** `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id>`
- - **Github Enterprise:** `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id> -- sourceUrl=https://ghe.custom.github.com/`
+ - **Github Enterprise:** `snyk-api-import orgs:data --source=github-enterprise --groupId=<snyk_group_id> -- sourceUrl=https://ghe.custom.github.com/`
 
 3. Use the generated data to feed into Snyk [Orgs API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) to generate the organizations within a group.
 

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -23,18 +23,23 @@ export const builder = {
   sourceUrl: {
     required: false,
     default: undefined,
-    desc: 'Custom base url for the source API that can list organizations (e.g. Github Enterprise url)',
+    desc:
+      'Custom base url for the source API that can list organizations (e.g. Github Enterprise url)',
   },
   source: {
     required: true,
     default: Sources.GITHUB,
-    choices: [Sources.GITHUB],
-    desc: 'The source of the targets to be imported e.g. Github',
+    choices: [...Object.values(Sources)],
+    desc:
+      'The source of the targets to be imported e.g. Github, Github Enterprise',
   },
 };
 
-const entityName = {
+const entityName: {
+  [source in Sources]: string;
+} = {
   github: 'org',
+  'github-enterprise': 'org',
 };
 
 export async function handler(argv: {

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -4,15 +4,25 @@ import { GithubOrgData, listGithubOrgs } from './github';
 
 export enum Sources {
   GITHUB = 'github',
+  GHE = 'github-enterprise',
+}
+
+async function githubEnterpriseOrganizations(sourceUrl?: string): Promise<{ name: string }[]> {
+  if (!sourceUrl) {
+    throw new Error('Please provide required `sourceUrl` for Github Enterprise source')
+  }
+  const ghOrgs: GithubOrgData[] = await listGithubOrgs(sourceUrl);
+  return ghOrgs;
 }
 
 async function githubOrganizations(sourceUrl?: string): Promise<{ name: string }[]> {
-  const ghOrgs: GithubOrgData[] = await listGithubOrgs(sourceUrl);
+  const ghOrgs: GithubOrgData[] = await listGithubOrgs();
   return ghOrgs;
 }
 
 const sourceGenerators = {
   [Sources.GITHUB]: githubOrganizations,
+  [Sources.GHE]: githubEnterpriseOrganizations,
 };
 
 export async function generateOrgImportDataFile(

--- a/src/scripts/github/list-orgs.ts
+++ b/src/scripts/github/list-orgs.ts
@@ -1,5 +1,4 @@
 import { Octokit } from '@octokit/rest';
-import { url } from 'inspector';
 import { getGithubBaseUrl } from './github-base-url';
 
 export interface GithubOrgData {

--- a/test/scripts/generate-org-data.test.ts
+++ b/test/scripts/generate-org-data.test.ts
@@ -6,13 +6,20 @@ import { deleteFiles } from '../delete-files';
 
 describe('generateOrgImportDataFile Github script', () => {
   const OLD_ENV = process.env;
-  process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
   process.env.SNYK_LOG_PATH = __dirname;
+  const filesToCleanup: string[] = [
+    __dirname + '/group-groupIdExample-github-com-orgs.json',
+    __dirname + '/group-groupIdExample-github-enterprise-orgs.json',
+  ];
   afterAll(async () => {
     process.env = { ...OLD_ENV };
-    await deleteFiles(['groupIdExample-sourceOrgIdExample-orgs.json']);
+  });
+
+  afterEach(async () => {
+    await deleteFiles(filesToCleanup);
   });
   it('generate Github Orgs data', async () => {
+    process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
     const groupId = 'groupIdExample';
     const sourceOrgId = 'sourceOrgIdExample';
 
@@ -30,10 +37,41 @@ describe('generateOrgImportDataFile Github script', () => {
     });
   });
   it('generate Github Orgs data without sourceOrgId', async () => {
+    process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
     const groupId = 'groupIdExample';
 
     const res = await generateOrgImportDataFile(Sources.GITHUB, groupId);
     expect(res.fileName).toEqual('group-groupIdExample-github-com-orgs.json');
+    expect(res.orgs.length > 0).toBeTruthy();
+    expect(res.orgs[0]).toEqual({
+      name: expect.any(String),
+      groupId,
+    });
+  });
+
+  it('generate Github Enterprise Orgs data without sourceUrl', async () => {
+    process.env.GITHUB_TOKEN = process.env.GHE_TOKEN;
+    const groupId = 'groupIdExample';
+
+    expect(generateOrgImportDataFile(Sources.GHE, groupId)).rejects.toThrow(
+      'Please provide required `sourceUrl` for Github Enterprise source',
+    );
+  });
+  it('generate Github Enterprise Orgs data', async () => {
+    process.env.GITHUB_TOKEN = process.env.TEST_GHE_TOKEN;
+    const GHE_URL = process.env.TEST_GHE_URL;
+
+    const groupId = 'groupIdExample';
+
+    const res = await generateOrgImportDataFile(
+      Sources.GHE,
+      groupId,
+      undefined,
+      GHE_URL,
+    );
+    expect(res.fileName).toEqual(
+      'group-groupIdExample-github-enterprise-orgs.json',
+    );
     expect(res.orgs.length > 0).toBeTruthy();
     expect(res.orgs[0]).toEqual({
       name: expect.any(String),

--- a/test/system/__snapshots__/generate-org-data.test.ts.snap
+++ b/test/system/__snapshots__/generate-org-data.test.ts.snap
@@ -18,8 +18,9 @@ Options:
                        settings)                                      [required]
   --sourceUrl          Custom base url for the source API that can list
                        organizations (e.g. Github Enterprise url)
-  --source             The source of the targets to be imported e.g. Github
-                              [required] [choices: "github"] [default: "github"]
+  --source             The source of the targets to be imported e.g. Github,
+                       Github Enterprise
+         [required] [choices: "github", "github-enterprise"] [default: "github"]
 
 Missing required argument: groupId
 ]
@@ -40,6 +41,7 @@ Options:
                        settings)                                      [required]
   --sourceUrl          Custom base url for the source API that can list
                        organizations (e.g. Github Enterprise url)
-  --source             The source of the targets to be imported e.g. Github
-                              [required] [choices: \\"github\\"] [default: \\"github\\"]"
+  --source             The source of the targets to be imported e.g. Github,
+                       Github Enterprise
+         [required] [choices: \\"github\\", \\"github-enterprise\\"] [default: \\"github\\"]"
 `;


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Keep source types the same as integration types to reduce any confusion while generated import data.