### PR TITLE
fix: use pagination for listing gh orgs

### DIFF
--- a/src/scripts/github/list-orgs.ts
+++ b/src/scripts/github/list-orgs.ts
@@ -1,11 +1,61 @@
 import { Octokit } from '@octokit/rest';
+import * as debugLib from 'debug';
+
 import { getGithubBaseUrl } from './github-base-url';
+
+const debug = debugLib('snyk:list-orgs-script');
 
 export interface GithubOrgData {
   name: string;
   id: number;
   url: string;
 }
+async function fetchOrgsForPage(
+  octokit: Octokit,
+  pageNumber = 1,
+): Promise<{
+  orgs: GithubOrgData[];
+  hasNextPage: boolean;
+}> {
+  const orgsData: GithubOrgData[] = [];
+  const params = {
+    per_page: 100,
+    page: pageNumber,
+  };
+  const res = await octokit.orgs.listForAuthenticatedUser(params);
+  const orgs = res && res.data;
+  let hasNextPage;
+  if (orgs.length) {
+    hasNextPage = true;
+    orgsData.push(
+      ...orgs.map((org) => ({
+        name: org.login,
+        id: org.id,
+        url: org.url,
+      })),
+    );
+  } else {
+    hasNextPage = false;
+  }
+  return { orgs: orgsData, hasNextPage };
+}
+
+async function fetchAllOrgs(
+  octokit: Octokit,
+  page = 0,
+): Promise<GithubOrgData[]> {
+  const orgsData: GithubOrgData[] = [];
+  let currentPage = page;
+  let hasMorePages = true;
+  while (hasMorePages) {
+    currentPage = currentPage + 1;
+    const { orgs, hasNextPage } = await fetchOrgsForPage(octokit, currentPage);
+    orgsData.push(...orgs);
+    hasMorePages = hasNextPage;
+  }
+  return orgsData;
+}
+
 export async function listGithubOrgs(host?: string): Promise<GithubOrgData[]> {
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
@@ -13,18 +63,11 @@ export async function listGithubOrgs(host?: string): Promise<GithubOrgData[]> {
       `Please set the GITHUB_TOKEN e.g. export GITHUB_TOKEN='mypersonalaccesstoken123'`,
     );
   }
-  const baseUrl = getGithubBaseUrl(host);
-  const octokit = new Octokit({ baseUrl, auth: githubToken });
-  const res = await octokit.orgs.listForAuthenticatedUser();
-  const orgsData = res && res.data;
 
-  if (!orgsData.length) {
-    return [];
-  }
-  const orgs: GithubOrgData[] = orgsData.map((org) => ({
-    name: org.login,
-    id: org.id,
-    url: org.url,
-  }));
+  const baseUrl = getGithubBaseUrl(host);
+  const octokit: Octokit = new Octokit({ baseUrl, auth: githubToken });
+
+  const orgs = await fetchAllOrgs(octokit);
+
   return orgs;
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Oktokit does not follow pages by default, adding in paginated calls manually.