### PR TITLE
feat: disable vuln settings on org creation

### DIFF
--- a/src/lib/org/index.ts
+++ b/src/lib/org/index.ts
@@ -43,23 +43,16 @@ export async function listIntegrations(
 const defaultDisabledSettings = {
   'new-issues-remediations': {
     enabled: false,
-    issueSeverity: 'high',
-    issueType: 'vuln',
+    issueType: 'none',
   },
   'project-imported': {
     enabled: false,
-    issueSeverity: 'high',
-    issueType: 'vuln',
   },
   'test-limit': {
     enabled: false,
-    issueSeverity: 'high',
-    issueType: 'vuln',
   },
   'weekly-report': {
     enabled: false,
-    issueSeverity: 'high',
-    issueType: 'vuln',
   },
 };
 

--- a/test/lib/orgs.test.ts
+++ b/test/lib/orgs.test.ts
@@ -34,8 +34,8 @@ describe('Single target', () => {
     expect(res).toEqual({
       'new-issues-remediations': {
         enabled: false,
-        issueSeverity: 'high',
-        issueType: 'vuln',
+        issueSeverity: 'all',
+        issueType: 'none',
       },
       'project-imported': {
         enabled: false,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Make sure all settings are disabled by setting the type to `none`