### PR TITLE
fix: use npm i instead of ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
                 color: '#42e2f4'
                 message: Starting snyk-api-import build-test-monitor job
             - checkout
-            - run: npm ci
+            - run: npm install
             - run: npm test
             - snyk/scan:
                 fail-on-issues: true


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
use npm install instead of ci since there is no lock.