### PR TITLE
fix: HACK - drop problem type file before pkg

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,6 +7,11 @@
       "cmd": "echo '' > dist/STANDALONE"
     },
     {
+      "//": "HACK: remove type file that causes pkg error https://github.com/octokit/openapi-types.ts/issues/16",
+      "path": "@semantic-release/exec",
+      "cmd": "node_modules/@octokit/openapi-types/generated/types.ts"
+    },
+    {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
       "cmd": "npx pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-watch": "tsc -w",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "pkg-binaries": "npx pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64 --out-path ./dist/binaries"
+    "pkg-binaries": "npx pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64"
   },
   "types": "./dist/index.d.ts",
   "repository": {

--- a/src/lib/org/index.ts
+++ b/src/lib/org/index.ts
@@ -44,6 +44,7 @@ const defaultDisabledSettings = {
   'new-issues-remediations': {
     enabled: false,
     issueType: 'none',
+    issueSeverity: 'high'
   },
   'project-imported': {
     enabled: false,

--- a/test/lib/orgs.test.ts
+++ b/test/lib/orgs.test.ts
@@ -34,7 +34,7 @@ describe('Single target', () => {
     expect(res).toEqual({
       'new-issues-remediations': {
         enabled: false,
-        issueSeverity: 'all',
+        issueSeverity: 'high',
         issueType: 'none',
       },
       'project-imported': {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Horrible HACK for now as no other work around could be found at this time to remove the problem type file before running pkg as it prevents the error & ends up building a valid working binary.