### PR TITLE
fix: fix typo - missed `rm` in the hack command

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@
     {
       "//": "HACK: remove type file that causes pkg error https://github.com/octokit/openapi-types.ts/issues/16",
       "path": "@semantic-release/exec",
-      "cmd": "node_modules/@octokit/openapi-types/generated/types.ts"
+      "cmd": "rm node_modules/@octokit/openapi-types/generated/types.ts"
     },
     {
       "//": "build the alpine, macos, linux and windows binaries",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Missed `rm` in a command to delete problem file