### PR TITLE
fix: only drop type just before pkg

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,14 +7,9 @@
       "cmd": "echo '' > dist/STANDALONE"
     },
     {
-      "//": "HACK: remove type file that causes pkg error https://github.com/octokit/openapi-types.ts/issues/16",
+      "//": "build the alpine, macos, linux and windows binaries. HACK: remove type file that causes pkg error https://github.com/octokit/openapi-types.ts/issues/16",
       "path": "@semantic-release/exec",
-      "cmd": "rm node_modules/@octokit/openapi-types/generated/types.ts"
-    },
-    {
-      "//": "build the alpine, macos, linux and windows binaries",
-      "path": "@semantic-release/exec",
-      "cmd": "npx pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64"
+      "cmd": "rm node_modules/@octokit/openapi-types/generated/types.ts && npx pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Try removing the types just before to avoid the ts error