### PR TITLE
fix: close quote on nexe extra files pattern

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,17 +9,17 @@
     {
       "//": "build the linux",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js -t mac-x64-10.21.0 -o snyk-api-import-macos"
+      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js' -t mac-x64-10.21.0 -o snyk-api-import-macos"
     },
     {
       "//": "build the macos",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js -t linux-x86-12.16.2 -o snyk-api-import-linux"
+      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js' -t linux-x86-12.16.2 -o snyk-api-import-linux"
     },
     {
       "//": "build the windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js -t windows-x64-10.16.0 -o snyk-api-import-win.exe"
+      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js' -t windows-x64-10.16.0 -o snyk-api-import-win.exe"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this do
Fix a type & close the quote for nexe files pattern