### PR TITLE
fix: ensure linux binary is 64bit

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -14,7 +14,7 @@
     {
       "//": "build the macos",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js' -t linux-x86-12.16.2 -o snyk-api-import-linux"
+      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js' -t linux-x64-12.16.2 -o snyk-api-import-linux"
     },
     {
       "//": "build the windows binaries",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Release linux as 64bit binary, migrating to nexe introduced a bug and caused 32bit to be released instead.