### PR TITLE
feat: refactor generate target ID

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -8,3 +8,14 @@ export const IMPORTED_BATCHES_LOG_NAME = 'imported-batches.log';
 export const IMPORT_JOB_RESULTS = 'import-job-results.log';
 export const CREATED_ORG_LOG_NAME = 'created-orgs.log'
 export const FAILED_ORG_LOG_NAME = 'failed-to-create-orgs.log'
+export const targetProps = [
+  'name',
+  'appId',
+  'functionId',
+  'slugId',
+  'projectKey',
+  'repoSlug',
+  'id',
+  'owner',
+  'branch',
+];

--- a/src/generate-target-id.ts
+++ b/src/generate-target-id.ts
@@ -1,0 +1,13 @@
+import * as _ from 'lodash';
+
+import { targetProps } from './common';
+import { Target } from './lib/types';
+
+export function generateTargetId(
+  orgId: string,
+  integrationId: string,
+  target: Target,
+): string {
+  const targetData =  _.pick(target, ...targetProps)
+  return `${orgId}:${integrationId}:${Object.values(targetData).join(':')}`;
+}

--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -7,10 +7,10 @@ import * as _ from 'lodash';
 import { Target, FilePath, ImportTarget } from '../types';
 import { getApiToken } from '../get-api-token';
 import { getSnykHost } from '../get-snyk-host';
-import { logImportedTarget } from '../../log-imported-targets';
+import { logImportedTarget } from '../../loggers/log-imported-targets';
 import { getLoggingPath } from '../get-logging-path';
-import { logFailedImports } from '../../log-failed-imports';
-import { logImportJobsPerOrg } from '../../log-import-jobs';
+import { logFailedImports } from '../../loggers/log-failed-imports';
+import { logImportJobsPerOrg } from '../../loggers/log-import-jobs';
 import { getConcurrentImportsNumber } from '../get-concurrent-imports-number';
 import { FAILED_LOG_NAME } from '../../common';
 

--- a/src/lib/poll-import/index.ts
+++ b/src/lib/poll-import/index.ts
@@ -7,10 +7,10 @@ import * as _ from 'lodash';
 import * as pMap from 'p-map';
 import { PollImportResponse, Project } from '../types';
 import { getApiToken } from '../get-api-token';
-import { logFailedProjects } from '../../log-failed-projects';
-import { logFailedPollUrls } from '../../log-failed-polls';
-import { logImportedProjects } from '../../log-imported-projects';
-import { logJobResult } from '../../log-job-result';
+import { logFailedProjects } from '../../loggers/log-failed-projects';
+import { logFailedPollUrls } from '../../loggers/log-failed-polls';
+import { logImportedProjects } from '../../loggers/log-imported-projects';
+import { logJobResult } from '../../loggers/log-job-result';
 
 const debug = debugLib('snyk:poll-import');
 const MIN_RETRY_WAIT_TIME = 20000;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,6 +17,8 @@ export interface CreatedOrg {
   origName: string; // name requested to be created
   sourceOrgId?: string;
 }
+
+// also must update targetProps if any new props are added
 export interface Target {
   name?: string; // Gitlab, GitHub, GH Enterprise, Bitbucket Cloud and Azure Repos, Bitbucket Server, Azure Container Registry, Elastic Container Registry, Artifactory Container Registry, Docker Hub
   appId?: string; // Heroku, CloudFoundry, Pivotal & IBM Cloud

--- a/src/loggers/log-created-org.ts
+++ b/src/loggers/log-created-org.ts
@@ -1,9 +1,9 @@
 import * as debugLib from 'debug';
 import * as bunyan from 'bunyan';
 
-import { getLoggingPath } from './lib/get-logging-path';
-import { CREATED_ORG_LOG_NAME } from './common';
-import { CreatedOrgResponse } from './lib';
+import { getLoggingPath } from '../lib/get-logging-path';
+import { CREATED_ORG_LOG_NAME } from '../common';
+import { CreatedOrgResponse } from '../lib';
 
 const debug = debugLib('snyk:create-orgs-script');
 

--- a/src/loggers/log-failed-imports.ts
+++ b/src/loggers/log-failed-imports.ts
@@ -1,9 +1,9 @@
 import * as debugLib from 'debug';
 import * as bunyan from 'bunyan';
 
-import { Target } from './lib/types';
-import { getLoggingPath } from './lib/get-logging-path';
-import { FAILED_LOG_NAME } from './common';
+import { Target } from './../lib/types';
+import { getLoggingPath } from './../lib/get-logging-path';
+import { FAILED_LOG_NAME } from './../common';
 
 const debug = debugLib('snyk:import-projects-script');
 

--- a/src/loggers/log-failed-org.ts
+++ b/src/loggers/log-failed-org.ts
@@ -1,8 +1,8 @@
 import * as debugLib from 'debug';
 import * as bunyan from 'bunyan';
 
-import { getLoggingPath } from './lib/get-logging-path';
-import { FAILED_ORG_LOG_NAME } from './common';
+import { getLoggingPath } from '../lib/get-logging-path';
+import { FAILED_ORG_LOG_NAME } from '../common';
 
 const debug = debugLib('snyk:create-orgs-script');
 

--- a/src/loggers/log-failed-polls.ts
+++ b/src/loggers/log-failed-polls.ts
@@ -1,8 +1,8 @@
 import * as bunyan from 'bunyan';
 import * as debugLib from 'debug';
 
-import { getLoggingPath } from './lib/get-logging-path';
-import { FAILED_POLLS_LOG_NAME } from './common';
+import { getLoggingPath } from './../lib/get-logging-path';
+import { FAILED_POLLS_LOG_NAME } from './../common';
 
 const debug = debugLib('snyk:import-projects-script');
 

--- a/src/loggers/log-failed-projects.ts
+++ b/src/loggers/log-failed-projects.ts
@@ -1,9 +1,9 @@
 import * as bunyan from 'bunyan';
 import * as debugLib from 'debug';
 
-import { FAILED_PROJECTS_LOG_NAME } from './common';
-import { Project } from './lib/types';
-import { getLoggingPath } from './lib/get-logging-path';
+import { FAILED_PROJECTS_LOG_NAME } from './../common';
+import { Project } from './../lib/types';
+import { getLoggingPath } from './../lib/get-logging-path';
 
 const debug = debugLib('snyk:import-projects-script');
 

--- a/src/loggers/log-import-jobs.ts
+++ b/src/loggers/log-import-jobs.ts
@@ -1,8 +1,8 @@
 import * as bunyan from 'bunyan';
 import * as debugLib from 'debug';
 
-import { getLoggingPath } from './lib/get-logging-path';
-import { IMPORT_JOBS_LOG_NAME } from './common';
+import { getLoggingPath } from './../lib/get-logging-path';
+import { IMPORT_JOBS_LOG_NAME } from './../common';
 
 const debug = debugLib('snyk:import-projects-script');
 

--- a/src/loggers/log-imported-batch.ts
+++ b/src/loggers/log-imported-batch.ts
@@ -1,8 +1,8 @@
 import * as bunyan from 'bunyan';
 import * as debugLib from 'debug';
 
-import { getLoggingPath } from './lib/get-logging-path';
-import { IMPORTED_BATCHES_LOG_NAME } from './common';
+import { getLoggingPath } from './../lib/get-logging-path';
+import { IMPORTED_BATCHES_LOG_NAME } from './../common';
 
 const debug = debugLib('snyk:import-projects-script');
 

--- a/src/loggers/log-imported-projects.ts
+++ b/src/loggers/log-imported-projects.ts
@@ -1,9 +1,9 @@
 import * as bunyan from 'bunyan';
 import * as debugLib from 'debug';
 
-import { getLoggingPath } from './lib/get-logging-path';
-import { Project } from './lib/types';
-import { IMPORTED_PROJECTS_LOG_NAME } from './common';
+import { getLoggingPath } from './../lib/get-logging-path';
+import { Project } from './../lib/types';
+import { IMPORTED_PROJECTS_LOG_NAME } from './../common';
 
 const debug = debugLib('snyk:import-projects-script');
 

--- a/src/loggers/log-imported-targets.ts
+++ b/src/loggers/log-imported-targets.ts
@@ -1,19 +1,12 @@
 import * as bunyan from 'bunyan';
 import * as debugLib from 'debug';
 
-import { Target } from './lib/types';
-import { getLoggingPath } from './lib/get-logging-path';
-import { IMPORT_LOG_NAME } from './common';
+import { Target } from './../lib/types';
+import { getLoggingPath } from './../lib/get-logging-path';
+import { IMPORT_LOG_NAME } from './../common';
+import { generateTargetId } from '../generate-target-id';
 
 const debug = debugLib('snyk:import-projects-script');
-
-export function generateImportedTargetData(
-  orgId: string,
-  integrationId: string,
-  target: Target,
-): string {
-  return `${orgId}:${integrationId}:${Object.values(target).join(':')}`;
-}
 
 export async function logImportedTarget(
   orgId: string,
@@ -39,7 +32,7 @@ export async function logImportedTarget(
         locationUrl,
         orgId,
         integrationId,
-        targetId: generateImportedTargetData(orgId, integrationId, target),
+        targetId: generateTargetId(orgId, integrationId, target),
       },
       'Target requested for import',
     );
@@ -49,7 +42,7 @@ export async function logImportedTarget(
         locationUrl,
         orgId,
         integrationId,
-        targetId: generateImportedTargetData(orgId, integrationId, target),
+        targetId: generateTargetId(orgId, integrationId, target),
       },
       'Target requested for import',
     );

--- a/src/loggers/log-job-result.ts
+++ b/src/loggers/log-job-result.ts
@@ -1,8 +1,8 @@
 import * as bunyan from 'bunyan';
-import { IMPORT_JOB_RESULTS } from './common';
+import { IMPORT_JOB_RESULTS } from './../common';
 
-import { getLoggingPath } from './lib/get-logging-path';
-import { PollImportResponse } from './lib/types';
+import { getLoggingPath } from './../lib/get-logging-path';
+import { PollImportResponse } from './../lib/types';
 
 export async function logJobResult(
   locationUrl: string,

--- a/src/scripts/create-orgs.ts
+++ b/src/scripts/create-orgs.ts
@@ -6,8 +6,8 @@ import { getLoggingPath } from '../lib/get-logging-path';
 import { listIntegrations, setNotificationPreferences } from '../lib/org';
 import { requestsManager } from 'snyk-request-manager';
 import { CreateOrgData } from '../lib/types';
-import { logCreatedOrg } from '../log-created-org';
-import { logFailedOrg } from '../log-failed-org';
+import { logCreatedOrg } from '../loggers/log-created-org';
+import { logFailedOrg } from '../loggers/log-failed-org';
 import { writeFile } from '../write-file';
 import { FAILED_ORG_LOG_NAME } from '../common';
 

--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -7,23 +7,23 @@ import { importTargets, pollImportUrls } from '../lib';
 import { Project, ImportTarget } from '../lib/types';
 import { getLoggingPath } from '../lib/get-logging-path';
 import { getConcurrentImportsNumber } from '../lib/get-concurrent-imports-number';
-import { logImportedBatch } from '../log-imported-batch';
-import { generateImportedTargetData } from '../log-imported-targets';
+import { logImportedBatch } from '../loggers/log-imported-batch';
 import { IMPORT_LOG_NAME } from '../common';
 import pMap = require('p-map');
+import { generateTargetId } from '../generate-target-id';
 
 const debug = debugLib('snyk:import-projects-script');
 
 const regexForTarget = (target: string): RegExp =>
   new RegExp(`(,?)${target}.*,`, 'm');
 
-async function skipTargetIfFoundInLog(
+export async function skipTargetIfFoundInLog(
   targetItem: ImportTarget,
   logFile: string,
 ): Promise<boolean> {
   const { orgId, integrationId, target } = targetItem;
   try {
-    const data = generateImportedTargetData(orgId, integrationId, target);
+    const data = generateTargetId(orgId, integrationId, target);
     const targetRegExp = regexForTarget(data);
     const match = logFile.match(targetRegExp);
     if (!match) {

--- a/test/lib/import-projects.test.ts
+++ b/test/lib/import-projects.test.ts
@@ -1,0 +1,183 @@
+import { skipTargetIfFoundInLog } from '../../src/scripts/import-projects';
+
+describe('Skip target if found in log', () => {
+  it('Target and empty log should not be skipped', async () => {
+    const target = {
+      name: 'composer-with-vulns',
+      owner: 'snyk-fixtures',
+      branch: 'master',
+    }
+    const importTarget = {
+      integrationId: 'INTEGRATION_ID',
+      orgId: 'ORG_ID',
+      target,
+    }
+    const shouldSkip = await skipTargetIfFoundInLog(importTarget, '');
+    expect(shouldSkip).toBeFalsy();
+
+    const shouldSkipAgain = await skipTargetIfFoundInLog(importTarget, undefined as unknown as string);
+    expect(shouldSkipAgain).toBeFalsy();
+  });
+  it('Target already in log should be skipped', async () => {
+    const target = {
+      name: 'composer-with-vulns',
+      owner: 'snyk-fixtures',
+      branch: 'master',
+    }
+    const importTarget = {
+      integrationId: 'INTEGRATION_ID',
+      orgId: 'ORG_ID',
+      target,
+    }
+    const singleImportedTargetLog = {
+      name: 'snyk:import-projects-script',
+      hostname: 'MacBook-Pro-2.local',
+      pid: 46657,
+      level: 30,
+      target,
+      locationUrl:
+        'https://snyk.io/api/v1/org/ORG_ID/integrations/INTEGRATION_ID/import/IMPORT_ID',
+      orgId: 'ORG_ID',
+      integrationId: 'INTEGRATION_ID',
+      targetId:
+        'ORG_ID:INTEGRATION_ID:composer-with-vulns:snyk-fixtures:master',
+      msg: 'Target requested for import',
+      time: '2020-10-26T14:53:20.234Z',
+      v: 0,
+    };
+
+    const shouldSkip = await skipTargetIfFoundInLog(importTarget, JSON.stringify(singleImportedTargetLog));
+    expect(shouldSkip).toBeTruthy();
+  });
+  it('Target already in log twice be skipped', async () => {
+    const target = {
+      name: 'composer-with-vulns',
+      owner: 'snyk-fixtures',
+      branch: 'master',
+    }
+    const importTarget = {
+      integrationId: 'INTEGRATION_ID',
+      orgId: 'ORG_ID',
+      target,
+    }
+    const singleImportedTargetLog = {
+      name: 'snyk:import-projects-script',
+      hostname: 'MacBook-Pro-2.local',
+      pid: 46657,
+      level: 30,
+      target,
+      locationUrl:
+        'https://snyk.io/api/v1/org/ORG_ID/integrations/INTEGRATION_ID/import/IMPORT_ID',
+      orgId: 'ORG_ID',
+      integrationId: 'INTEGRATION_ID',
+      targetId:
+        'ORG_ID:INTEGRATION_ID:composer-with-vulns:snyk-fixtures:master',
+      msg: 'Target requested for import',
+      time: '2020-10-26T14:53:20.234Z',
+      v: 0,
+    };
+
+    const shouldSkip = await skipTargetIfFoundInLog(importTarget, JSON.stringify(singleImportedTargetLog) + JSON.stringify(singleImportedTargetLog));
+    expect(shouldSkip).toBeTruthy();
+  });
+  it('Target not in log should not be skipped', async () => {
+    const target = {
+      name: 'composer-with-vulns',
+      owner: 'snyk-fixtures',
+      branch: 'master',
+    }
+    const importTarget = {
+      integrationId: 'INTEGRATION_ID',
+      orgId: 'ORG_ID',
+      target: {
+        ...target,
+        branch: 'develop'
+      },
+    }
+    const singleImportedTargetLog = {
+      name: 'snyk:import-projects-script',
+      hostname: 'MacBook-Pro-2.local',
+      pid: 46657,
+      level: 30,
+      target,
+      locationUrl:
+        'https://snyk.io/api/v1/org/ORG_ID/integrations/INTEGRATION_ID/import/IMPORT_ID',
+      orgId: 'ORG_ID',
+      integrationId: 'INTEGRATION_ID',
+      targetId:
+        'ORG_ID:INTEGRATION_ID:composer-with-vulns:snyk-fixtures:master',
+      msg: 'Target requested for import',
+      time: '2020-10-26T14:53:20.234Z',
+      v: 0,
+    };
+
+    const shouldSkip = await skipTargetIfFoundInLog(importTarget, JSON.stringify(singleImportedTargetLog));
+    expect(shouldSkip).toBeFalsy();
+  });
+  it('Target with extra meta but already in log should be skipped', async () => {
+    const target = {
+      name: 'composer-with-vulns',
+      owner: 'snyk-fixtures',
+      branch: 'master',
+      forked: true,
+      isPrivate: false,
+    }
+    const importTarget = {
+      integrationId: 'INTEGRATION_ID',
+      orgId: 'ORG_ID',
+      target,
+    }
+    const singleImportedTargetLog = {
+      name: 'snyk:import-projects-script',
+      hostname: 'MacBook-Pro-2.local',
+      pid: 46657,
+      level: 30,
+      target,
+      locationUrl:
+        'https://snyk.io/api/v1/org/ORG_ID/integrations/INTEGRATION_ID/import/IMPORT_ID',
+      orgId: 'ORG_ID',
+      integrationId: 'INTEGRATION_ID',
+      targetId:
+        'ORG_ID:INTEGRATION_ID:composer-with-vulns:snyk-fixtures:master',
+      msg: 'Target requested for import',
+      time: '2020-10-26T14:53:20.234Z',
+      v: 0,
+    };
+
+    const shouldSkip = await skipTargetIfFoundInLog(importTarget, JSON.stringify(singleImportedTargetLog));
+    expect(shouldSkip).toBeTruthy();
+  });
+  it('Same target but for different org should not be skipped', async () => {
+    const target = {
+      name: 'composer-with-vulns',
+      owner: 'snyk-fixtures',
+      branch: 'master',
+      forked: true,
+      isPrivate: false,
+    }
+    const importTarget = {
+      integrationId: 'INTEGRATION_ID_NEW',
+      orgId: 'ORG_ID_NEW',
+      target,
+    }
+    const singleImportedTargetLog = {
+      name: 'snyk:import-projects-script',
+      hostname: 'MacBook-Pro-2.local',
+      pid: 46657,
+      level: 30,
+      target,
+      locationUrl:
+        'https://snyk.io/api/v1/org/ORG_ID/integrations/INTEGRATION_ID/import/IMPORT_ID',
+      orgId: 'ORG_ID',
+      integrationId: 'INTEGRATION_ID',
+      targetId:
+        'ORG_ID:INTEGRATION_ID:composer-with-vulns:snyk-fixtures:master',
+      msg: 'Target requested for import',
+      time: '2020-10-26T14:53:20.234Z',
+      v: 0,
+    };
+
+    const shouldSkip = await skipTargetIfFoundInLog(importTarget, JSON.stringify(singleImportedTargetLog));
+    expect(shouldSkip).toBeFalsy();
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

- add tests to ensure targets are correctly skipped
- move all logging utils into logging folder
- update generate target ID functionality to only pick out supported target fields
