### PR TITLE
feat: pin nexe to older working version

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,17 +9,17 @@
     {
       "//": "build the linux",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js' -t mac-x64-10.21.0 -o snyk-api-import-macos"
+      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t mac-x64-10.21.0 -o snyk-api-import-macos"
     },
     {
       "//": "build the macos",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js' -t linux-x64-12.16.2 -o snyk-api-import-linux"
+      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t linux-x64-12.16.2 -o snyk-api-import-linux"
     },
     {
       "//": "build the windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe dist/index.js  -r './dist/**/*.js' -t windows-x64-10.16.0 -o snyk-api-import-win.exe"
+      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t windows-x64-10.16.0 -o snyk-api-import-win.exe"
     },
     {
       "//": "shasum all binaries",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-watch": "tsc -w",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "pkg-binaries": "npx nexe dist/index.js -r './dist/**/*.js' -t mac-x64-10.21.0 -o snyk-api-import-macos"
+    "pkg-binaries": "npx  nexe@3.3.7 dist/index.js -r './dist/**/*.js' -t mac-x64-10.21.0 -o snyk-api-import-macos"
   },
   "types": "./dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

https://github.com/nexe/nexe/issues/755
Latest beta nexe version stopped working as expected, pinning to previously working version.

