### PR TITLE
feat: support to skip Bitbucket Cloud projects during re-import

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -109,6 +109,12 @@ Note:
 - The same target imported into a different org will be allowed to be imported
 - The same target (but different branch) will be allowed to be imported
 - The same target from a differed source be allowed to be imported (For example the same repo is present in Github and now it being imported via Github Enterprise into the same org)
-### Github.com / Github Enterprise
-- `snyk-api-import-macos list:imported --integrationType=github-enterprise --groupId=<snyk_group_id>`
-- `snyk-api-import-macos list:imported --integrationType=github --groupId=<snyk_group_id>`
+
+
+Command to run:
+`snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
+
+Supported integration types:
+- Github.com `github`
+- Github Enterprise `github-enterprise`
+- Bitbucket Cloud `bitbucket-cloud`

--- a/src/cmds/import:data.ts
+++ b/src/cmds/import:data.ts
@@ -2,11 +2,12 @@ import * as debugLib from 'debug';
 import { getLoggingPath } from '../lib/get-logging-path';
 const debug = debugLib('snyk:generate-data-script');
 
-import { CreatedOrg, Sources, SupportedIntegrationTypes } from '../lib/types';
-import { loadFile } from '../load-file';
 import {
-  generateTargetsImportDataFile,
-} from '../scripts/generate-targets-data';
+  CreatedOrg,
+  SupportedIntegrationTypesToGenerateImportData,
+} from '../lib/types';
+import { loadFile } from '../load-file';
+import { generateTargetsImportDataFile } from '../scripts/generate-targets-data';
 
 export const command = ['import:data'];
 export const desc =
@@ -19,8 +20,8 @@ export const builder = {
   },
   source: {
     required: true,
-    default: Sources.GITHUB,
-    choices: [...Object.values(Sources)],
+    default: SupportedIntegrationTypesToGenerateImportData.GITHUB,
+    choices: [...Object.values(SupportedIntegrationTypesToGenerateImportData)],
     desc:
       'The source of the targets to be imported e.g. Github, Github Enterprise. This will be used to make an API call to list all available entities per org',
   },
@@ -33,23 +34,23 @@ export const builder = {
   integrationType: {
     required: true,
     default: undefined,
-    choices: [...Object.values(SupportedIntegrationTypes)],
+    choices: [...Object.values(SupportedIntegrationTypesToGenerateImportData)],
     desc:
       'The configured integration type on the created Snyk Org to use for generating import targets data. Applies to all targets.',
   },
 };
 
 const entityName: {
-  [source in Sources]: string;
+  [source in SupportedIntegrationTypesToGenerateImportData]: string;
 } = {
   github: 'org',
   'github-enterprise': 'org',
 };
 
 export async function handler(argv: {
-  source: Sources;
+  source: SupportedIntegrationTypesToGenerateImportData;
   orgsData: string;
-  integrationType: SupportedIntegrationTypes;
+  integrationType: SupportedIntegrationTypesToGenerateImportData;
   sourceUrl: string;
 }): Promise<void> {
   try {
@@ -68,9 +69,7 @@ export async function handler(argv: {
       );
     }
     if (orgsDataJson.length === 0) {
-      throw new Error(
-        `No orgs could be loaded from ${orgsData}.`,
-      );
+      throw new Error(`No orgs could be loaded from ${orgsData}.`);
     }
     const res = await generateTargetsImportDataFile(
       source,

--- a/src/cmds/list:imported.ts
+++ b/src/cmds/list:imported.ts
@@ -1,8 +1,8 @@
 import * as debugLib from 'debug';
 import { getLoggingPath } from '../lib/get-logging-path';
+import { SupportedIntegrationTypesToListSnykTargets } from '../lib/types';
 const debug = debugLib('snyk:generate-data-script');
 
-import { SupportedIntegrationTypes } from '../lib/types';
 import { generateSnykImportedTargets } from '../scripts/generate-imported-targets-from-snyk';
 
 export const command = ['list:imported'];
@@ -17,22 +17,23 @@ export const builder = {
   integrationType: {
     required: true,
     default: undefined,
-    choices: [...Object.values(SupportedIntegrationTypes)],
+    choices: [...Object.values(SupportedIntegrationTypesToListSnykTargets)],
     desc:
       'The configured integration type (source of the projects in Snyk e.g. Github, Github Enterprise.). This will be used to pick the correct integrationID from each org in Snyk',
   },
 };
 
 const entityName: {
-  [source in SupportedIntegrationTypes]: string;
+  [source in SupportedIntegrationTypesToListSnykTargets]: string;
 } = {
   github: 'repo',
   'github-enterprise': 'repo',
+  'bitbucket-cloud': 'repo',
 };
 
 export async function handler(argv: {
   groupId: string;
-  integrationType: SupportedIntegrationTypes;
+  integrationType: SupportedIntegrationTypesToListSnykTargets;
 }): Promise<void> {
   getLoggingPath();
   const { groupId, integrationType } = argv;

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -2,7 +2,7 @@ import * as debugLib from 'debug';
 const debug = debugLib('snyk:generate-data-script');
 
 import { getLoggingPath } from '../lib/get-logging-path';
-import { Sources } from '../lib/types';
+import { SupportedIntegrationTypesToGenerateImportData } from '../lib/types';
 import { generateOrgImportDataFile } from '../scripts/generate-org-data';
 
 export const command = ['orgs:data'];
@@ -29,22 +29,22 @@ export const builder = {
   },
   source: {
     required: true,
-    default: Sources.GITHUB,
-    choices: [...Object.values(Sources)],
+    default: SupportedIntegrationTypesToGenerateImportData.GITHUB,
+    choices: [...Object.values(SupportedIntegrationTypesToGenerateImportData)],
     desc:
       'The source of the targets to be imported e.g. Github, Github Enterprise',
   },
 };
 
 const entityName: {
-  [source in Sources]: string;
+  [source in SupportedIntegrationTypesToGenerateImportData]: string;
 } = {
   github: 'org',
   'github-enterprise': 'org',
 };
 
 export async function handler(argv: {
-  source: Sources;
+  source: SupportedIntegrationTypesToGenerateImportData;
   groupId: string;
   sourceOrgPublicId?: string;
   sourceUrl?: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,16 +69,21 @@ export interface PollImportResponse {
   created: string;
   logs: Log[];
 }
-export enum SupportedIntegrationTypes {
+
+// used to generate import data by connecting to the source via API
+// and listing all orgs + repos / targets
+export enum SupportedIntegrationTypesToGenerateImportData {
   GITHUB = 'github',
   GHE = 'github-enterprise',
 }
 
-export enum Sources {
+// used to generate imported targets that exist in Snyk
+// when we need to grab the integrationId from Snyk
+export enum SupportedIntegrationTypesToListSnykTargets {
   GITHUB = 'github',
   GHE = 'github-enterprise',
+  BITBUCKET_CLOUD = 'bitbucket-cloud',
 }
-
 interface ImportingUser {
   id: string;
   name: string;

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -1,10 +1,17 @@
-import { CreateOrgData, Sources } from '../lib/types';
+import {
+  CreateOrgData,
+  SupportedIntegrationTypesToGenerateImportData,
+} from '../lib/types';
 import { writeFile } from '../write-file';
 import { GithubOrgData, listGithubOrgs } from './github';
 
-async function githubEnterpriseOrganizations(sourceUrl?: string): Promise<{ name: string }[]> {
+async function githubEnterpriseOrganizations(
+  sourceUrl?: string,
+): Promise<{ name: string }[]> {
   if (!sourceUrl) {
-    throw new Error('Please provide required `sourceUrl` for Github Enterprise source')
+    throw new Error(
+      'Please provide required `sourceUrl` for Github Enterprise source',
+    );
   }
   const ghOrgs: GithubOrgData[] = await listGithubOrgs(sourceUrl);
   return ghOrgs;
@@ -16,12 +23,12 @@ async function githubOrganizations(): Promise<{ name: string }[]> {
 }
 
 const sourceGenerators = {
-  [Sources.GITHUB]: githubOrganizations,
-  [Sources.GHE]: githubEnterpriseOrganizations,
+  [SupportedIntegrationTypesToGenerateImportData.GITHUB]: githubOrganizations,
+  [SupportedIntegrationTypesToGenerateImportData.GHE]: githubEnterpriseOrganizations,
 };
 
 export async function generateOrgImportDataFile(
-  source: Sources,
+  source: SupportedIntegrationTypesToGenerateImportData,
   groupId: string,
   sourceOrgId?: string,
   sourceUrl?: string,
@@ -40,7 +47,9 @@ export async function generateOrgImportDataFile(
     }
     orgData.push(data);
   }
-  const fileName = `group-${groupId}-${sourceUrl? 'github-enterprise' : 'github-com'}-orgs.json`;
+  const fileName = `group-${groupId}-${
+    sourceUrl ? 'github-enterprise' : 'github-com'
+  }-orgs.json`;
   await writeFile(fileName, ({
     orgs: orgData,
   } as unknown) as JSON);

--- a/src/scripts/generate-targets-data.ts
+++ b/src/scripts/generate-targets-data.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import { CreatedOrg, ImportTarget, Sources, SupportedIntegrationTypes } from '../lib/types';
+import { CreatedOrg, ImportTarget, SupportedIntegrationTypesToGenerateImportData } from '../lib/types';
 import { writeFile } from '../write-file';
 import { GithubRepoData, listGithubRepos } from './github';
 
@@ -21,8 +21,8 @@ async function githubEnterpriseRepos(
 }
 
 const sourceGenerators = {
-  [Sources.GITHUB]: githubRepos,
-  [Sources.GHE]: githubEnterpriseRepos,
+  [SupportedIntegrationTypesToGenerateImportData.GITHUB]: githubRepos,
+  [SupportedIntegrationTypesToGenerateImportData.GHE]: githubEnterpriseRepos,
 };
 
 function validateRequiredOrgData(
@@ -47,22 +47,22 @@ function validateRequiredOrgData(
   if (
     _.intersection(
       Object.keys(integrations),
-      Object.values(SupportedIntegrationTypes),
+      Object.values(SupportedIntegrationTypesToGenerateImportData),
     ).length === 0
   ) {
     throw new Error(
       'At least one supported integration is expected in `integrations` field.' +
         `Supported integrations are: ${Object.values(
-          SupportedIntegrationTypes,
+          SupportedIntegrationTypesToGenerateImportData,
         ).join(',')}`,
     );
   }
 }
 
 export async function generateTargetsImportDataFile(
-  source: Sources,
+  source: SupportedIntegrationTypesToGenerateImportData,
   orgsData: CreatedOrg[],
-  integrationType: SupportedIntegrationTypes,
+  integrationType: SupportedIntegrationTypesToGenerateImportData,
   sourceUrl?: string,
 ): Promise<{ targets: ImportTarget[]; fileName: string }> {
   const targetsData: ImportTarget[] = [];

--- a/test/scripts/generate-imported-targets-from-snyk.test.ts
+++ b/test/scripts/generate-imported-targets-from-snyk.test.ts
@@ -3,9 +3,12 @@ import * as path from 'path';
 
 import { generateLogsPaths } from '../generate-log-file-names';
 import { deleteFiles } from '../delete-files';
-import { SupportedIntegrationTypes } from '../../src/lib/types';
-import { generateSnykImportedTargets } from '../../src/scripts/generate-imported-targets-from-snyk';
+import {
+  generateSnykImportedTargets,
+  projectToTarget,
+} from '../../src/scripts/generate-imported-targets-from-snyk';
 import { IMPORT_LOG_NAME } from '../../src/common';
+import { SupportedIntegrationTypesToListSnykTargets } from '../../src/lib/types';
 
 const ORG_ID = process.env.TEST_ORG_ID as string;
 const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
@@ -31,7 +34,7 @@ describe('Generate imported targets based on Snyk data', () => {
     logs = Object.values(logFiles);
     const { targets, failedOrgs, fileName } = await generateSnykImportedTargets(
       GROUP_ID,
-      SupportedIntegrationTypes.GITHUB,
+      SupportedIntegrationTypesToListSnykTargets.GITHUB,
     );
     expect(failedOrgs).toEqual([]);
     expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
@@ -52,4 +55,17 @@ describe('Generate imported targets based on Snyk data', () => {
     expect(importedTargetsLog).toMatch(targets[0].integrationId);
   }, 240000);
   it.todo('One org failed to be processed');
+
+  it('succeed to convert Github project name to target', async () => {
+    const project = {
+      name: 'lili-snyk/huge-monorepo:cockroach/build/builder/Dockerfile',
+      branch: 'main',
+    };
+    const target = projectToTarget(project);
+    expect(target).toEqual({
+      branch: 'main',
+      name: 'huge-monorepo',
+      owner: 'lili-snyk',
+    });
+  });
 });

--- a/test/scripts/generate-org-data.test.ts
+++ b/test/scripts/generate-org-data.test.ts
@@ -1,7 +1,5 @@
-import { Sources } from '../../src/lib/types';
-import {
-  generateOrgImportDataFile,
-} from '../../src/scripts/generate-org-data';
+import { SupportedIntegrationTypesToGenerateImportData } from '../../src/lib/types';
+import { generateOrgImportDataFile } from '../../src/scripts/generate-org-data';
 import { deleteFiles } from '../delete-files';
 
 describe('generateOrgImportDataFile Github script', () => {
@@ -24,7 +22,7 @@ describe('generateOrgImportDataFile Github script', () => {
     const sourceOrgId = 'sourceOrgIdExample';
 
     const res = await generateOrgImportDataFile(
-      Sources.GITHUB,
+      SupportedIntegrationTypesToGenerateImportData.GITHUB,
       groupId,
       sourceOrgId,
     );
@@ -40,7 +38,10 @@ describe('generateOrgImportDataFile Github script', () => {
     process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
     const groupId = 'groupIdExample';
 
-    const res = await generateOrgImportDataFile(Sources.GITHUB, groupId);
+    const res = await generateOrgImportDataFile(
+      SupportedIntegrationTypesToGenerateImportData.GITHUB,
+      groupId,
+    );
     expect(res.fileName).toEqual('group-groupIdExample-github-com-orgs.json');
     expect(res.orgs.length > 0).toBeTruthy();
     expect(res.orgs[0]).toEqual({
@@ -53,7 +54,12 @@ describe('generateOrgImportDataFile Github script', () => {
     process.env.GITHUB_TOKEN = process.env.GHE_TOKEN;
     const groupId = 'groupIdExample';
 
-    expect(generateOrgImportDataFile(Sources.GHE, groupId)).rejects.toThrow(
+    expect(
+      generateOrgImportDataFile(
+        SupportedIntegrationTypesToGenerateImportData.GHE,
+        groupId,
+      ),
+    ).rejects.toThrow(
       'Please provide required `sourceUrl` for Github Enterprise source',
     );
   });
@@ -64,7 +70,7 @@ describe('generateOrgImportDataFile Github script', () => {
     const groupId = 'groupIdExample';
 
     const res = await generateOrgImportDataFile(
-      Sources.GHE,
+      SupportedIntegrationTypesToGenerateImportData.GHE,
       groupId,
       undefined,
       GHE_URL,

--- a/test/scripts/generate-targets-data.test.ts
+++ b/test/scripts/generate-targets-data.test.ts
@@ -1,9 +1,10 @@
 import * as _ from 'lodash';
 import * as path from 'path';
-import { CreatedOrg, Sources, SupportedIntegrationTypes } from '../../src/lib/types';
 import {
-  generateTargetsImportDataFile,
-} from '../../src/scripts/generate-targets-data';
+  CreatedOrg,
+  SupportedIntegrationTypesToGenerateImportData,
+} from '../../src/lib/types';
+import { generateTargetsImportDataFile } from '../../src/scripts/generate-targets-data';
 import { deleteFiles } from '../delete-files';
 
 describe('generateTargetsImportDataFile Github script', () => {
@@ -32,9 +33,9 @@ describe('generateTargetsImportDataFile Github script', () => {
     ];
 
     const res = await generateTargetsImportDataFile(
-      Sources.GITHUB,
+      SupportedIntegrationTypesToGenerateImportData.GITHUB,
       orgsData,
-      SupportedIntegrationTypes.GITHUB,
+      SupportedIntegrationTypesToGenerateImportData.GITHUB,
     );
     expect(res.fileName).toEqual('github-import-targets.json');
     expect(res.targets.length > 0).toBeTruthy();
@@ -69,9 +70,9 @@ describe('generateTargetsImportDataFile Github script', () => {
     ];
 
     const res = await generateTargetsImportDataFile(
-      Sources.GHE,
+      SupportedIntegrationTypesToGenerateImportData.GHE,
       orgsData,
-      SupportedIntegrationTypes.GHE,
+      SupportedIntegrationTypesToGenerateImportData.GHE,
       GHE_URL,
     );
     expect(res.fileName).toEqual('github-enterprise-import-targets.json');
@@ -103,9 +104,9 @@ describe('generateTargetsImportDataFile Github script', () => {
 
     expect(
       generateTargetsImportDataFile(
-        Sources.GITHUB,
+        SupportedIntegrationTypesToGenerateImportData.GITHUB,
         orgsData,
-        SupportedIntegrationTypes.GITHUB,
+        SupportedIntegrationTypesToGenerateImportData.GITHUB,
       ),
     ).rejects.toThrow(
       'No targets could be generated. Check the error output & try again.',
@@ -141,9 +142,9 @@ describe('generateTargetsImportDataFile Github script', () => {
     ];
 
     const res = await generateTargetsImportDataFile(
-      Sources.GITHUB,
+      SupportedIntegrationTypesToGenerateImportData.GITHUB,
       orgsData,
-      SupportedIntegrationTypes.GITHUB,
+      SupportedIntegrationTypesToGenerateImportData.GITHUB,
     );
     expect(res.fileName).toEqual('github-import-targets.json');
     expect(res.targets.length > 0).toBeTruthy();

--- a/test/system/__snapshots__/generate-imported-targets-from-snyk.test.ts.snap
+++ b/test/system/__snapshots__/generate-imported-targets-from-snyk.test.ts.snap
@@ -17,7 +17,7 @@ Options:
   --integrationType  The configured integration type (source of the projects in
                      Snyk e.g. Github, Github Enterprise.). This will be used to
                      pick the correct integrationID from each org in Snyk
-                             [required] [choices: "github", "github-enterprise"]
+          [required] [choices: "github", "github-enterprise", "bitbucket-cloud"]
 
 Missing required argument: groupId
 ]
@@ -39,5 +39,5 @@ Options:
   --integrationType  The configured integration type (source of the projects in
                      Snyk e.g. Github, Github Enterprise.). This will be used to
                      pick the correct integrationID from each org in Snyk
-                             [required] [choices: \\"github\\", \\"github-enterprise\\"]"
+          [required] [choices: \\"github\\", \\"github-enterprise\\", \\"bitbucket-cloud\\"]"
 `;


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Allow the list:imported command to also convert Bitbucket Cloud
projects into "imported targets" so they can be skipped