### PR TITLE
feat: allow multiple integration types to list imported projects

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -116,7 +116,8 @@ Command to run:
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
 - skip all previously imported for a specific Organization:
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --orgId=<snyk_org_id>`
-
+- a single integration / projects source `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
+-  multiple integrations / projects sources `snyk-api-import-macos list:imported --integrationType=<integration-type> --integrationType=<integration-type> --orgId=<snyk_org_id>`
 
 Supported integration types:
 - Github.com `github`

--- a/src/lib/api/import/index.ts
+++ b/src/lib/api/import/index.ts
@@ -69,9 +69,7 @@ export async function importTarget(
       `Received locationUrl for ${target.name || 'target'}: ${locationUrl}`,
     );
     await logImportedTargets(
-      orgId,
-      integrationId,
-      [target],
+      [{ target, integrationId, orgId }],
       locationUrl,
       loggingPath,
     );

--- a/src/loggers/log-imported-targets.ts
+++ b/src/loggers/log-imported-targets.ts
@@ -1,15 +1,13 @@
 import * as bunyan from 'bunyan';
 import * as _ from 'lodash';
 
-import { Target } from './../lib/types';
+import { ImportTarget } from './../lib/types';
 import { IMPORT_LOG_NAME, targetProps } from './../common';
 import { getLoggingPath } from './../lib';
 import { generateTargetId } from '../generate-target-id';
 
 export async function logImportedTargets(
-  orgId: string,
-  integrationId: string,
-  targets: Target[],
+  targets: ImportTarget[],
   locationUrl: string | null,
   loggingPath: string = getLoggingPath(),
   message = 'Target requested for import',
@@ -27,7 +25,8 @@ export async function logImportedTargets(
       ],
     });
 
-    for (const target of targets) {
+    for (const data of targets) {
+      const { integrationId, target, orgId } = data;
       log.info(
         {
           target: _.pick(target, ...targetProps),

--- a/test/scripts/generate-imported-targets-from-snyk.test.ts
+++ b/test/scripts/generate-imported-targets-from-snyk.test.ts
@@ -30,13 +30,16 @@ describe('Generate imported targets based on Snyk data', () => {
     process.env = { ...OLD_ENV };
   });
 
-  it('succeeds to generate targets for Group', async () => {
+  it('succeeds to generate targets for Group for Github', async () => {
     const logFiles = generateLogsPaths(__dirname, ORG_ID);
     logs = Object.values(logFiles);
-    const { targets, failedOrgs, fileName } = await generateSnykImportedTargets(
-      { groupId: GROUP_ID },
+    const {
+      targets,
+      failedOrgs,
+      fileName,
+    } = await generateSnykImportedTargets({ groupId: GROUP_ID }, [
       SupportedIntegrationTypesToListSnykTargets.GITHUB,
-    );
+    ]);
     expect(failedOrgs).toEqual([]);
     expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
     expect(targets[0]).toMatchObject({
@@ -56,13 +59,76 @@ describe('Generate imported targets based on Snyk data', () => {
     expect(importedTargetsLog).toMatch(targets[0].integrationId);
   }, 240000);
 
-  it('succeeds to generate targets for Org', async () => {
+  it('succeeds to generate targets for Org + Github', async () => {
     const logFiles = generateLogsPaths(__dirname, ORG_ID);
     logs = Object.values(logFiles);
-    const { targets, failedOrgs, fileName } = await generateSnykImportedTargets(
-      { orgId: ORG_ID },
+    const {
+      targets,
+      failedOrgs,
+      fileName,
+    } = await generateSnykImportedTargets({ orgId: ORG_ID }, [
       SupportedIntegrationTypesToListSnykTargets.GITHUB,
-    );
+    ]);
+    expect(failedOrgs).toEqual([]);
+    expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
+    expect(targets[0]).toMatchObject({
+      integrationId: expect.any(String),
+      orgId: expect.any(String),
+      target: {
+        branch: expect.any(String),
+        name: expect.any(String),
+        owner: expect.any(String),
+      },
+    });
+    // give file a little time to be finished to be written
+    await new Promise((r) => setTimeout(r, 20000));
+    const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
+    expect(importedTargetsLog).toMatch(targets[0].target.owner as string);
+    expect(importedTargetsLog).toMatch(targets[0].orgId);
+    expect(importedTargetsLog).toMatch(targets[0].integrationId);
+  }, 240000);
+
+  it('succeeds to generate targets for Group for Github & Github Enterprise', async () => {
+    const logFiles = generateLogsPaths(__dirname, ORG_ID);
+    logs = Object.values(logFiles);
+    const {
+      targets,
+      failedOrgs,
+      fileName,
+    } = await generateSnykImportedTargets({ groupId: GROUP_ID }, [
+      SupportedIntegrationTypesToListSnykTargets.GITHUB,
+      SupportedIntegrationTypesToListSnykTargets.GHE,
+    ]);
+    expect(failedOrgs).toEqual([]);
+    expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
+    expect(targets[0]).toMatchObject({
+      integrationId: expect.any(String),
+      orgId: expect.any(String),
+      target: {
+        branch: expect.any(String),
+        name: expect.any(String),
+        owner: expect.any(String),
+      },
+    });
+    // give file a little time to be finished to be written
+    await new Promise((r) => setTimeout(r, 20000));
+    const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
+    expect(importedTargetsLog).toMatch(targets[0].target.owner as string);
+    expect(importedTargetsLog).toMatch(targets[0].orgId);
+    expect(importedTargetsLog).toMatch(targets[0].integrationId);
+  }, 240000);
+
+  it('succeeds to generate targets for Org for Github & Github Enterprise', async () => {
+    const logFiles = generateLogsPaths(__dirname, ORG_ID);
+    logs = Object.values(logFiles);
+    const {
+      targets,
+      failedOrgs,
+      fileName,
+    } = await generateSnykImportedTargets({ orgId: ORG_ID }, [
+      SupportedIntegrationTypesToListSnykTargets.GITHUB,
+      SupportedIntegrationTypesToListSnykTargets.GHE,
+    ]);
     expect(failedOrgs).toEqual([]);
     expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
     expect(targets[0]).toMatchObject({

--- a/test/system/__snapshots__/generate-imported-targets-from-snyk.test.ts.snap
+++ b/test/system/__snapshots__/generate-imported-targets-from-snyk.test.ts.snap
@@ -17,7 +17,9 @@ Options:
                      organization settings)
   --integrationType  The configured integration type (source of the projects in
                      Snyk e.g. Github, Github Enterprise.). This will be used to
-                     pick the correct integrationID from each organization in
-                     Snyk
-   [required] [choices: \\"github\\", \\"github-enterprise\\", \\"bitbucket-cloud\\", \\"gcr\\"]"
+                     pick the correct integrationID from each org in Snyk E.g.
+                     --integrationType=github
+                     --integrationType=github-enterprise
+   [required] [choices: \\"github\\", \\"github-enterprise\\", \\"bitbucket-cloud\\", \\"gcr\\"]
+                                                                   [default: []]"
 `;

--- a/test/system/generate-imported-targets-from-snyk.test.ts
+++ b/test/system/generate-imported-targets-from-snyk.test.ts
@@ -25,7 +25,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
     });
   });
 
-  it('Generates Snyk imported targets data as expected for Group', async (done) => {
+  it('Generates Snyk imported targets data as expected for github + Group', async (done) => {
     return exec(
       `node ${main} list:imported --integrationType=github --groupId=${GROUP_ID}`,
       {
@@ -52,7 +52,34 @@ describe('`snyk-api-import list:imported <...>`', () => {
       },
     );
   }, 10000);
-  it('Generates Snyk imported targets data as expected for Org', async (done) => {
+  it('Generates Snyk imported targets data as expected for multiple integrations for an Org', async (done) => {
+    return exec(
+      `node ${main} list:imported --integrationType=github --integrationType=github-enterprise --orgId=${ORG_ID}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TOKEN_TEST,
+          SNYK_API: process.env.SNYK_API_TEST,
+          SNYK_LOG_PATH: __dirname,
+        },
+      },
+      (err, stdout) => {
+        if (err) {
+          throw err;
+        }
+        expect(err).toBeNull();
+        expect(stdout.trim()).toMatch(
+          `target(s). Written the data to file: ${path.resolve(
+            __dirname,
+            'imported-targets.log',
+          )}`,
+        );
+        deleteFiles([path.resolve(__dirname, IMPORT_LOG_NAME)]);
+        done();
+      },
+    );
+  }, 10000);
+  it('Generates Snyk imported targets data as expected for an Org', async (done) => {
     return exec(
       `node ${main} list:imported --integrationType=github --orgId=${ORG_ID}`,
       {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Allow listing projects in Snyk for multiple integration types that are provides like so: 
```
snyk-api-import list:imported --integrationType=github --integrationType=github-enterprise --groupId=<groun_id>
```
