### PR TITLE
feat: list imported targets for specific org

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -112,7 +112,11 @@ Note:
 
 
 Command to run:
+- skip all previously imported into all orgs in a Group:
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
+- skip all previously imported for a specific Organization:
+`snyk-api-import-macos list:imported --integrationType=<integration-type> --orgId=<snyk_org_id>`
+
 
 Supported integration types:
 - Github.com `github`

--- a/test/scripts/generate-imported-targets-from-snyk.test.ts
+++ b/test/scripts/generate-imported-targets-from-snyk.test.ts
@@ -33,7 +33,33 @@ describe('Generate imported targets based on Snyk data', () => {
     const logFiles = generateLogsPaths(__dirname, ORG_ID);
     logs = Object.values(logFiles);
     const { targets, failedOrgs, fileName } = await generateSnykImportedTargets(
-      GROUP_ID,
+      { groupId: GROUP_ID },
+      SupportedIntegrationTypesToListSnykTargets.GITHUB,
+    );
+    expect(failedOrgs).toEqual([]);
+    expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
+    expect(targets[0]).toMatchObject({
+      integrationId: expect.any(String),
+      orgId: expect.any(String),
+      target: {
+        branch: expect.any(String),
+        name: expect.any(String),
+        owner: expect.any(String),
+      },
+    });
+    // give file a little time to be finished to be written
+    await new Promise((r) => setTimeout(r, 20000));
+    const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
+    expect(importedTargetsLog).toMatch(targets[0].target.owner as string);
+    expect(importedTargetsLog).toMatch(targets[0].orgId);
+    expect(importedTargetsLog).toMatch(targets[0].integrationId);
+  }, 240000);
+
+  it('succeeds to generate targets for Org', async () => {
+    const logFiles = generateLogsPaths(__dirname, ORG_ID);
+    logs = Object.values(logFiles);
+    const { targets, failedOrgs, fileName } = await generateSnykImportedTargets(
+      { orgId: ORG_ID },
       SupportedIntegrationTypesToListSnykTargets.GITHUB,
     );
     expect(failedOrgs).toEqual([]);

--- a/test/system/__snapshots__/generate-imported-targets-from-snyk.test.ts.snap
+++ b/test/system/__snapshots__/generate-imported-targets-from-snyk.test.ts.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`\`snyk-api-import list:imported <...>\` Shows error when missing groupId 1`] = `
-[Error: Command failed: node ./dist/index.js list:imported --integrationType=github
-index.js list:imported
-
-List all targets imported in Snyk for a given group & source type. An analysis
-is performed on all current organizations and their projects to generate this.
-The generated file can be used to skip previously imported targets when running
-the \`import\` command
-
-Options:
-  --version          Show version number                               [boolean]
-  --help             Show help                                         [boolean]
-  --groupId          Public id of the group in Snyk (available on group
-                     settings)                                        [required]
-  --integrationType  The configured integration type (source of the projects in
-                     Snyk e.g. Github, Github Enterprise.). This will be used to
-                     pick the correct integrationID from each organization in
-                     Snyk
-          [required] [choices: "github", "github-enterprise", "bitbucket-cloud"]
-
-Missing required argument: groupId
-]
-`;
-
 exports[`\`snyk-api-import list:imported <...>\` Shows help text as expected 1`] = `
 "index.js list:imported
 
@@ -36,7 +12,9 @@ Options:
   --version          Show version number                               [boolean]
   --help             Show help                                         [boolean]
   --groupId          Public id of the group in Snyk (available on group
-                     settings)                                        [required]
+                     settings)
+  --orgId            Public id of the organization in Snyk (available in
+                     organization settings)
   --integrationType  The configured integration type (source of the projects in
                      Snyk e.g. Github, Github Enterprise.). This will be used to
                      pick the correct integrationID from each organization in


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Allow user to target a specific organization when listing imported targets