### PR TITLE
feat: add support for generating target also for docker-hub

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -124,3 +124,4 @@ Supported integration types:
 - Github Enterprise `github-enterprise`
 - Bitbucket Cloud `bitbucket-cloud`
 - Google Cloud Registry `gcr`
+- DockerHub registry `docker-hub`

--- a/src/cmds/list:imported.ts
+++ b/src/cmds/list:imported.ts
@@ -37,6 +37,7 @@ const entityName: {
   'github-enterprise': 'repo',
   'bitbucket-cloud': 'repo',
   gcr: 'images',
+  'docker-hub': 'images',
 };
 
 export async function handler(argv: {
@@ -77,7 +78,7 @@ export async function handler(argv: {
 
     if (failedOrgs.length > 0) {
       console.warn(
-        `Failed to process the following orgs: ${failedOrgs.join(',')}`,
+        `Failed to process the following orgs: ${failedOrgs.map(org => org.id).join(',')}`,
       );
     }
     console.log(targetsMessage);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -84,6 +84,7 @@ export enum SupportedIntegrationTypesToListSnykTargets {
   GHE = 'github-enterprise',
   BITBUCKET_CLOUD = 'bitbucket-cloud',
   GCR = 'gcr',
+  DOCKER_HUB = 'docker-hub'
 }
 interface ImportingUser {
   id: string;

--- a/src/scripts/generate-imported-targets-from-snyk.ts
+++ b/src/scripts/generate-imported-targets-from-snyk.ts
@@ -54,6 +54,7 @@ const targetGenerators = {
   [SupportedIntegrationTypesToListSnykTargets.GHE]: projectToTarget,
   [SupportedIntegrationTypesToListSnykTargets.BITBUCKET_CLOUD]: projectToTarget,
   [SupportedIntegrationTypesToListSnykTargets.GCR]: imageProjectToTarget,
+  [SupportedIntegrationTypesToListSnykTargets.DOCKER_HUB]: imageProjectToTarget,
 };
 
 interface SnykOrg {

--- a/test/system/__snapshots__/generate-imported-targets-from-snyk.test.ts.snap
+++ b/test/system/__snapshots__/generate-imported-targets-from-snyk.test.ts.snap
@@ -20,6 +20,6 @@ Options:
                      pick the correct integrationID from each org in Snyk E.g.
                      --integrationType=github
                      --integrationType=github-enterprise
-   [required] [choices: \\"github\\", \\"github-enterprise\\", \\"bitbucket-cloud\\", \\"gcr\\"]
-                                                                   [default: []]"
+   [required] [choices: \\"github\\", \\"github-enterprise\\", \\"bitbucket-cloud\\", \\"gcr\\",
+                                                     \\"docker-hub\\"] [default: []]"
 `;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Add support for `docker-hub` in `list:imported` command
