### PR TITLE
fix: reduce open handles when logging failed projects

### DIFF
--- a/src/loggers/log-failed-projects.ts
+++ b/src/loggers/log-failed-projects.ts
@@ -7,26 +7,43 @@ import { getLoggingPath } from './../lib';
 
 const debug = debugLib('snyk:import-projects-script');
 
-// TODO: convert this but think about easily scannable? we need target! and error
+export interface FailedProject extends Project {
+  locationUrl: string;
+}
+
 export async function logFailedProjects(
-  locationUrl: string,
-  projects: Project[],
+  projects: FailedProject[],
   loggingPath: string = getLoggingPath(),
 ): Promise<void> {
   try {
-    projects.forEach((project) => {
-      const orgId = locationUrl.split('/').slice(-5)[0];
+    const projectsPerOrg: {
+      [orgName: string]: Project[];
+    } = {};
+    projects.forEach((p) => {
+      const orgId = p.locationUrl.split('/').slice(-5)[0];
+      if (!projectsPerOrg[orgId]) {
+        projectsPerOrg[orgId] = [p];
+      } else {
+        projectsPerOrg.orgId.push(p);
+      }
+    });
+
+    for (const orgId in projectsPerOrg) {
       const log = bunyan.createLogger({
         name: 'snyk:import-projects-script',
         level: 'error',
-        streams: [{
-          level: 'error',
-          path: `${loggingPath}/${orgId}.${FAILED_PROJECTS_LOG_NAME}`,
-        }],
+        streams: [
+          {
+            level: 'error',
+            path: `${loggingPath}/${orgId}.${FAILED_PROJECTS_LOG_NAME}`,
+          },
+        ],
       });
-      debug({ orgId, locationUrl, ...project }, 'Error importing project')
-      log.error({ orgId, locationUrl, ...project }, 'Error importing project');
-    });
+      projectsPerOrg[orgId].forEach((project) => {
+        debug({ orgId, ...project }, 'Error importing project');
+        log.error({ orgId, ...project }, 'Error importing project');
+      });
+    }
   } catch (e) {
     // do nothing
   }

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -172,7 +172,7 @@ describe('Skips & logs issues', () => {
     );
     expect(failedProjectsLog).not.toBeNull();
     expect(failedProjectsLog).toMatch(
-      `"targetFile":"dotnet/invalid.csproj","success":false,"userMessage":"Failed to process manifest dotnet/invalid.csproj","projectUrl":"","msg":"Error importing project"`,
+      `"targetFile":"dotnet/invalid.csproj","success":false,"userMessage":"Failed to process manifest dotnet/invalid.csproj","projectUrl":""`,
     );
 
     let failedImportLog = null;


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Reduce open handles by logging all projects once at the end and creating 1 logger per org.