### PR TITLE
Re-updated types to include support for the new critical severity by Snyk due to PR close by mistake

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,7 @@ export interface SnykProject {
     low: number;
     high: number;
     medium: number;
+    critical: number;
   };
   remoteRepoUrl: string; // URL of the repo
   lastTestedDate: string;


### PR DESCRIPTION
chore: Updated types to include support for the new critical severity