### PR TITLE
feat: support Gitlab for import repo data generation

### DIFF
--- a/docs/import-data.md
+++ b/docs/import-data.md
@@ -1,9 +1,15 @@
 # Creating import targets data for import
 
-This is a util that can help generate the import json data needed t=by the import command.
+This is a util that can help generate the import json data needed by the import command.
 
-## `import:data`
+## Table of Contents
+- Usage
+  - [Github](#githubcom--github-enterprise)
+  - [Gitlab](#gitlabcom--hosted-gitlab)
+- [Recommendations](#recommendations)
 
+
+# `import:data`
 ### Github.com / Github Enterprise
 1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
 2. You will need to have the organizations data in json as an input to this command to help map Snyk organization IDs and Integration Ids that must be used during import against individual targets to be imported. The following format is required:
@@ -23,14 +29,42 @@ This is a util that can help generate the import json data needed t=by the impor
   }
   ```
   Note: the "name" of the Github/Github Enterprise organization is required in order
-  to list all repos belonging to that organization via Github API, the Snyk specific data accompanying that organization name will be used as the information to genrate import data assuming all repos in that organization will be imported into a given Snyk organisation. This is opinionated! If you want to customise this please manually craft the import data described in [import.md](/docs/import.md)
+  to list all repos belonging to that organization via Github API, the Snyk specific data accompanying that organization name will be used as the information to generate import data assuming all repos in that organization will be imported into a given Snyk organization. This is opinionated! If you want to customize this please manually craft the import data described in [import.md](/docs/import.md)
   - Github/Github Enterprise organizations can be listed using the [/orgs API](https://docs.github.com/en/free-pro-team@latest/rest/reference/orgs)
-  - Integrations can be listed via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/integrations/integrations/list)
-  - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk API](https://snyk.docs.apiary.io/#reference/organizations/the-snyk-organization-for-a-request/list-all-the-organizations-a-user-belongs-to)
+  - Integrations can be listed via [Snyk Integrations API](https://snyk.docs.apiary.io/#reference/integrations/integrations/list)
+  - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
 
 3. Run the command to generate import data:
  - **Github.com:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github --integrationType=github`
  - **Github Enterprise:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise --integrationType=github-enterprise --sourceUrl=https://ghe.custom.com`
+
+4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
+
+### Gitlab.com / Hosted Gitlab
+1. set the [Gitlab personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) as an environment variable: `export GITLAB_TOKEN=your_personal_access_token`
+2. You will need to have the organizations data in json as an input to this command to help map Snyk organization IDs and Integration Ids that must be used during import against individual targets to be imported. The following format is required:
+  ```
+  {
+    "orgData": [
+      {
+        "name": "<group_name_in_gitlab_used_to_list_repos>",
+        "orgId": "<snyk_org_id>",
+        "integrations": {
+          "gitlab": "<snyk_org_integration_id>",
+        },
+      },
+      {...}
+    ]
+  }
+  ```
+  Note: the "name" of the Gitlab Group is required in order to list all projects belonging to that Group via Gitlab API, the Snyk specific data accompanying that Group name will be used as the information to generate import data assuming all projects in that Group will be imported into a given Snyk organization. This is opinionated! If you want to customize this please manually craft the import data described in [import.md](/docs/import.md)
+  - Gitlab Groups can be listed using the [/groups API](https://docs.gitlab.com/ee/api/groups.html)
+  - Integrations can be listed via [Snyk Integrations API](https://snyk.docs.apiary.io/#reference/integrations/integrations/list)
+  - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
+
+3. Run the command to generate import data:
+ - **Gitlab.com:** `DEBUG=snyk* GITLAB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=gitlab --integrationType=gitlab`
+ - **Hosted Gitlab:** `DEBUG=snyk* GITLAB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=gitlab --integrationType=gitlab --sourceUrl=https://gitlab.custom.com`
 
 4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "homepage": "https://github.com/snyk-tech-services/snyk-api-import#readme",
   "dependencies": {
+    "@gitbeaker/node": "30.5.0",
     "@octokit/rest": "18.5.4",
     "@snyk/configstore": "^3.2.0-rc1",
     "axios": "^0.21.0",

--- a/src/cmds/import:data.ts
+++ b/src/cmds/import:data.ts
@@ -4,7 +4,7 @@ const debug = debugLib('snyk:generate-data-script');
 
 import {
   CreatedOrg,
-  SupportedIntegrationTypesToGenerateImportData,
+  SupportedIntegrationTypesImportData,
 } from '../lib/types';
 import { loadFile } from '../load-file';
 import { generateTargetsImportDataFile } from '../scripts/generate-targets-data';
@@ -20,10 +20,10 @@ export const builder = {
   },
   source: {
     required: true,
-    default: SupportedIntegrationTypesToGenerateImportData.GITHUB,
-    choices: [...Object.values(SupportedIntegrationTypesToGenerateImportData)],
+    default: SupportedIntegrationTypesImportData.GITHUB,
+    choices: [...Object.values(SupportedIntegrationTypesImportData)],
     desc:
-      'The source of the targets to be imported e.g. Github, Github Enterprise. This will be used to make an API call to list all available entities per org',
+      'The source of the targets to be imported e.g. Github, Github Enterprise, Gitlab. This will be used to make an API call to list all available entities per org',
   },
   sourceUrl: {
     required: false,
@@ -34,23 +34,24 @@ export const builder = {
   integrationType: {
     required: true,
     default: undefined,
-    choices: [...Object.values(SupportedIntegrationTypesToGenerateImportData)],
+    choices: [...Object.values(SupportedIntegrationTypesImportData)],
     desc:
       'The configured integration type on the created Snyk Org to use for generating import targets data. Applies to all targets.',
   },
 };
 
 const entityName: {
-  [source in SupportedIntegrationTypesToGenerateImportData]: string;
+  [source in SupportedIntegrationTypesImportData]: string;
 } = {
   github: 'org',
   'github-enterprise': 'org',
+  'gitlab': 'group',
 };
 
 export async function handler(argv: {
-  source: SupportedIntegrationTypesToGenerateImportData;
+  source: SupportedIntegrationTypesImportData;
   orgsData: string;
-  integrationType: SupportedIntegrationTypesToGenerateImportData;
+  integrationType: SupportedIntegrationTypesImportData;
   sourceUrl: string;
 }): Promise<void> {
   try {
@@ -65,11 +66,11 @@ export async function handler(argv: {
       orgsDataJson = [...orgsJson.orgData];
     } catch (e) {
       throw new Error(
-        `Failed to parse organizations from ${orgsData}. ERROR: ${e.message}`,
+        `Failed to parse ${entityName[source]}s from ${orgsData}. ERROR: ${e.message}`,
       );
     }
     if (orgsDataJson.length === 0) {
-      throw new Error(`No organizations could be loaded from ${orgsData}.`);
+      throw new Error(`No ${entityName[source]}s could be loaded from ${orgsData}.`);
     }
     const res = await generateTargetsImportDataFile(
       source,

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -2,7 +2,7 @@ import * as debugLib from 'debug';
 const debug = debugLib('snyk:generate-data-script');
 
 import { getLoggingPath } from '../lib/get-logging-path';
-import { SupportedIntegrationTypesToGenerateImportData } from '../lib/types';
+import { SupportedIntegrationTypesImportOrgData } from '../lib/types';
 import { entityName, generateOrgImportDataFile } from '../scripts/generate-org-data';
 
 export const command = ['orgs:data'];
@@ -33,15 +33,15 @@ export const builder = {
   },
   source: {
     required: true,
-    default: SupportedIntegrationTypesToGenerateImportData.GITHUB,
-    choices: [...Object.values(SupportedIntegrationTypesToGenerateImportData)],
+    default: SupportedIntegrationTypesImportOrgData.GITHUB,
+    choices: [...Object.values(SupportedIntegrationTypesImportOrgData)],
     desc:
       'The source of the targets to be imported e.g. Github, Github Enterprise',
   },
 };
 
 export async function handler(argv: {
-  source: SupportedIntegrationTypesToGenerateImportData;
+  source: SupportedIntegrationTypesImportOrgData;
   groupId: string;
   sourceOrgPublicId?: string;
   sourceUrl?: string;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,3 +13,4 @@ export * from './filter-out-existing-orgs';
 
 
 export * from './source-handlers/github';
+export * from './source-handlers/gitlab';

--- a/src/lib/source-handlers/github/index.ts
+++ b/src/lib/source-handlers/github/index.ts
@@ -1,5 +1,4 @@
 export * from './list-organizations';
-export * from './list-repos';
+export { listGithubRepos } from './list-repos';
 export * from './organization-is-empty';
 export * from './types';
-

--- a/src/lib/source-handlers/gitlab/get-base-url.ts
+++ b/src/lib/source-handlers/gitlab/get-base-url.ts
@@ -1,0 +1,3 @@
+export function getBaseUrl(host?: string): string {
+  return host ? host : 'https://gitlab.com';
+}

--- a/src/lib/source-handlers/gitlab/get-token.ts
+++ b/src/lib/source-handlers/gitlab/get-token.ts
@@ -1,0 +1,9 @@
+export function getToken(): string {
+  const token = process.env.GITLAB_TOKEN;
+  if (!token) {
+    throw new Error(
+      `Please set the GITLAB_TOKEN e.g. export GITLAB_TOKEN='mypersonalaccesstoken123'`,
+    );
+  }
+  return token;
+}

--- a/src/lib/source-handlers/gitlab/index.ts
+++ b/src/lib/source-handlers/gitlab/index.ts
@@ -1,0 +1,2 @@
+export { listGitlabRepos } from './list-repos';
+export  * from './types';

--- a/src/lib/source-handlers/gitlab/list-repos.ts
+++ b/src/lib/source-handlers/gitlab/list-repos.ts
@@ -1,0 +1,78 @@
+import { Gitlab } from '@gitbeaker/node';
+import * as debugLib from 'debug';
+import { getToken } from './get-token';
+
+import { getBaseUrl } from './get-base-url';
+import * as types from '@gitbeaker/core/dist/types';
+import { GitlabRepoData } from './types';
+
+const debug = debugLib('snyk:list-repos-script');
+
+export async function fetchGitlabReposForPage(
+  client: types.Gitlab,
+  groupName: string,
+  pageNumber = 1,
+  perPage = 100,
+): Promise<{
+  repos: GitlabRepoData[];
+  hasNextPage: boolean;
+}> {
+  const repoData: GitlabRepoData[] = [];
+  const params = {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    perPage,
+    page: pageNumber,
+  };
+  const projects = await client.Groups.projects(groupName, params);
+  let hasNextPage;
+  if (projects.length) {
+    hasNextPage = true;
+    repoData.push(
+      ...projects
+        .filter((project: any) => !project.archived)
+        .map((project: any) => ({
+          fork: !!project.forked_from_project,
+          name: project.path_with_namespace,
+          id: project.id,
+          branch: project.default_branch,
+        })),
+    );
+  } else {
+    hasNextPage = false;
+  }
+  return { repos: repoData, hasNextPage };
+}
+
+async function fetchAllRepos(
+  client: types.Gitlab,
+  groupName: string,
+  page = 0,
+): Promise<GitlabRepoData[]> {
+  const repoData: GitlabRepoData[] = [];
+  let currentPage = page;
+  let hasMorePages = true;
+  while (hasMorePages) {
+    currentPage = currentPage + 1;
+    debug(`Fetching page: ${currentPage}`);
+    const { repos, hasNextPage } = await fetchGitlabReposForPage(
+      client,
+      groupName,
+      currentPage,
+    );
+    hasMorePages = hasNextPage;
+    repoData.push(...repos);
+  }
+  return repoData;
+}
+
+export async function listGitlabRepos(
+  groupName: string,
+  host?: string,
+): Promise<GitlabRepoData[]> {
+  const token = getToken();
+  const baseUrl = getBaseUrl(host);
+  const client = new Gitlab({ host: baseUrl, token });
+  debug(`Fetching all repos data for org \`${groupName}\` from ${baseUrl}`);
+  const repos = await fetchAllRepos(client, groupName);
+  return repos;
+}

--- a/src/lib/source-handlers/gitlab/types.ts
+++ b/src/lib/source-handlers/gitlab/types.ts
@@ -1,0 +1,6 @@
+export interface GitlabRepoData {
+  // fork: boolean;
+  branch: string;
+  id: number;
+  name: string;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,8 +71,16 @@ export interface PollImportResponse {
 }
 
 // used to generate import data by connecting to the source via API
-// and listing all orgs + repos / targets
-export enum SupportedIntegrationTypesToGenerateImportData {
+// and listing all repos / targets per given org
+export enum SupportedIntegrationTypesImportData {
+  GITHUB = 'github',
+  GHE = 'github-enterprise',
+  GITLAB = 'gitlab',
+}
+
+// used to generate import data by connecting to the source via API
+// and listing all orgs
+export enum SupportedIntegrationTypesImportOrgData {
   GITHUB = 'github',
   GHE = 'github-enterprise',
 }

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -7,29 +7,29 @@ import {
 } from '../lib/source-handlers/github';
 import {
   CreateOrgData,
-  SupportedIntegrationTypesToGenerateImportData,
+  SupportedIntegrationTypesImportOrgData,
 } from '../lib/types';
 import { writeFile } from '../write-file';
 
 const sourceGenerators = {
-  [SupportedIntegrationTypesToGenerateImportData.GITHUB]: githubOrganizations,
-  [SupportedIntegrationTypesToGenerateImportData.GHE]: githubEnterpriseOrganizations,
+  [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizations,
+  [SupportedIntegrationTypesImportOrgData.GHE]: githubEnterpriseOrganizations,
 };
 
 const sourceNotEmpty = {
-  [SupportedIntegrationTypesToGenerateImportData.GITHUB]: githubOrganizationIsEmpty,
-  [SupportedIntegrationTypesToGenerateImportData.GHE]: githubOrganizationIsEmpty,
+  [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizationIsEmpty,
+  [SupportedIntegrationTypesImportOrgData.GHE]: githubOrganizationIsEmpty,
 };
 
 export const entityName: {
-  [source in SupportedIntegrationTypesToGenerateImportData]: string;
+  [source in SupportedIntegrationTypesImportOrgData]: string;
 } = {
   github: 'organization',
   'github-enterprise': 'organization',
 };
 
 export async function generateOrgImportDataFile(
-  source: SupportedIntegrationTypesToGenerateImportData,
+  source: SupportedIntegrationTypesImportOrgData,
   groupId: string,
   sourceOrgId?: string,
   sourceUrl?: string,

--- a/test/lib/source-handlers/github/github.test.ts
+++ b/test/lib/source-handlers/github/github.test.ts
@@ -1,5 +1,5 @@
-import { listGithubOrgs } from '../../src/lib/source-handlers/github/list-organizations';
-import { listGithubRepos } from '../../src/lib/source-handlers/github/list-repos';
+import { listGithubOrgs } from '../../../../src/lib/source-handlers/github/list-organizations';
+import { listGithubRepos } from '../../../../src/lib/source-handlers/github/list-repos';
 
 describe('listGithubOrgs script', () => {
   const OLD_ENV = process.env;

--- a/test/lib/source-handlers/gitlab/list-repos.test.ts
+++ b/test/lib/source-handlers/gitlab/list-repos.test.ts
@@ -1,0 +1,23 @@
+import { listGitlabRepos } from '../../../../src/lib/source-handlers/gitlab/list-repos';
+
+describe('listGitlabRepos', () => {
+  const OLD_ENV = process.env;
+
+  afterEach(async () => {
+    process.env = { ...OLD_ENV };
+  });
+  it('list repos (Gitlab Custom URL)', async () => {
+    const GITLAB_BASE_URL = process.env.TEST_GITLAB_BASE_URL;
+    const GITLAB_ORG_NAME = process.env.TEST_GITLAB_ORG_NAME;
+    process.env.GITLAB_TOKEN = process.env.TEST_GITLAB_TOKEN;
+
+    const repos = await listGitlabRepos(GITLAB_ORG_NAME as string, GITLAB_BASE_URL);
+    expect(repos.length >= 1).toBeTruthy();
+    expect(repos[0]).toEqual({
+      name: expect.any(String),
+      id: expect.any(Number),
+      branch: expect.any(String),
+      fork: expect.any(Boolean),
+    });
+  });
+});

--- a/test/scripts/generate-org-data.test.ts
+++ b/test/scripts/generate-org-data.test.ts
@@ -1,4 +1,4 @@
-import { SupportedIntegrationTypesToGenerateImportData } from '../../src/lib/types';
+import { SupportedIntegrationTypesImportOrgData } from '../../src/lib/types';
 import { generateOrgImportDataFile } from '../../src/scripts/generate-org-data';
 import { deleteFiles } from '../delete-files';
 
@@ -22,7 +22,7 @@ describe('generateOrgImportDataFile Github script', () => {
     const sourceOrgId = 'sourceOrgIdExample';
 
     const res = await generateOrgImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GITHUB,
+      SupportedIntegrationTypesImportOrgData.GITHUB,
       groupId,
       sourceOrgId,
       undefined,
@@ -43,7 +43,7 @@ describe('generateOrgImportDataFile Github script', () => {
     const sourceOrgId = 'sourceOrgIdExample';
 
     const res = await generateOrgImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GITHUB,
+      SupportedIntegrationTypesImportOrgData.GITHUB,
       groupId,
       sourceOrgId,
       undefined,
@@ -63,7 +63,7 @@ describe('generateOrgImportDataFile Github script', () => {
     const groupId = 'groupIdExample';
 
     const res = await generateOrgImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GITHUB,
+      SupportedIntegrationTypesImportOrgData.GITHUB,
       groupId,
     );
     expect(res.fileName).toEqual('group-groupIdExample-github-com-orgs.json');
@@ -81,7 +81,7 @@ describe('generateOrgImportDataFile Github script', () => {
 
     expect(
       generateOrgImportDataFile(
-        SupportedIntegrationTypesToGenerateImportData.GHE,
+        SupportedIntegrationTypesImportOrgData.GHE,
         groupId,
       ),
     ).rejects.toThrow(
@@ -94,7 +94,7 @@ describe('generateOrgImportDataFile Github script', () => {
 
     const groupId = 'groupIdExample';
     const res = await generateOrgImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GHE,
+      SupportedIntegrationTypesImportOrgData.GHE,
       groupId,
       undefined,
       GHE_URL,
@@ -115,7 +115,7 @@ describe('generateOrgImportDataFile Github script', () => {
 
     const groupId = 'groupIdExample';
     const res = await generateOrgImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GHE,
+      SupportedIntegrationTypesImportOrgData.GHE,
       groupId,
       undefined,
       GHE_URL,

--- a/test/scripts/generate-targets-data.test.ts
+++ b/test/scripts/generate-targets-data.test.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as path from 'path';
 import {
   CreatedOrg,
-  SupportedIntegrationTypesToGenerateImportData,
+  SupportedIntegrationTypesImportData,
 } from '../../src/lib/types';
 import { generateTargetsImportDataFile } from '../../src/scripts/generate-targets-data';
 import { deleteFiles } from '../delete-files';
@@ -33,9 +33,9 @@ describe('generateTargetsImportDataFile Github script', () => {
     ];
 
     const res = await generateTargetsImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GITHUB,
+      SupportedIntegrationTypesImportData.GITHUB,
       orgsData,
-      SupportedIntegrationTypesToGenerateImportData.GITHUB,
+      SupportedIntegrationTypesImportData.GITHUB,
     );
     expect(res.fileName).toEqual('github-import-targets.json');
     expect(res.targets.length > 0).toBeTruthy();
@@ -70,9 +70,9 @@ describe('generateTargetsImportDataFile Github script', () => {
     ];
 
     const res = await generateTargetsImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GHE,
+      SupportedIntegrationTypesImportData.GHE,
       orgsData,
-      SupportedIntegrationTypesToGenerateImportData.GHE,
+      SupportedIntegrationTypesImportData.GHE,
       GHE_URL,
     );
     expect(res.fileName).toEqual('github-enterprise-import-targets.json');
@@ -104,9 +104,9 @@ describe('generateTargetsImportDataFile Github script', () => {
 
     expect(
       generateTargetsImportDataFile(
-        SupportedIntegrationTypesToGenerateImportData.GITHUB,
+        SupportedIntegrationTypesImportData.GITHUB,
         orgsData,
-        SupportedIntegrationTypesToGenerateImportData.GITHUB,
+        SupportedIntegrationTypesImportData.GITHUB,
       ),
     ).rejects.toThrow(
       'No targets could be generated. Check the error output & try again.',
@@ -142,9 +142,9 @@ describe('generateTargetsImportDataFile Github script', () => {
     ];
 
     const res = await generateTargetsImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GITHUB,
+      SupportedIntegrationTypesImportData.GITHUB,
       orgsData,
-      SupportedIntegrationTypesToGenerateImportData.GITHUB,
+      SupportedIntegrationTypesImportData.GITHUB,
     );
     expect(res.fileName).toEqual('github-import-targets.json');
     expect(res.targets.length > 0).toBeTruthy();
@@ -190,9 +190,9 @@ describe('generateTargetsImportDataFile Gitlab script', () => {
     ];
 
     const res = await generateTargetsImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GITLAB,
+      SupportedIntegrationTypesImportData.GITLAB,
       orgsData,
-      SupportedIntegrationTypesToGenerateImportData.GITLAB,
+      SupportedIntegrationTypesImportData.GITLAB,
       GITLAB_BASE_URL,
     );
     expect(res.fileName).toEqual('gitlab-import-targets.json');
@@ -227,9 +227,9 @@ describe('generateTargetsImportDataFile Gitlab script', () => {
 
     expect(
       generateTargetsImportDataFile(
-        SupportedIntegrationTypesToGenerateImportData.GITLAB,
+        SupportedIntegrationTypesImportData.GITLAB,
         orgsData,
-        SupportedIntegrationTypesToGenerateImportData.GITLAB,
+        SupportedIntegrationTypesImportData.GITLAB,
         GITLAB_BASE_URL,
       ),
     ).rejects.toThrow(
@@ -268,9 +268,9 @@ describe('generateTargetsImportDataFile Gitlab script', () => {
     ];
 
     const res = await generateTargetsImportDataFile(
-      SupportedIntegrationTypesToGenerateImportData.GITLAB,
+      SupportedIntegrationTypesImportData.GITLAB,
       orgsData,
-      SupportedIntegrationTypesToGenerateImportData.GITLAB,
+      SupportedIntegrationTypesImportData.GITLAB,
       GITLAB_BASE_URL
     );
     expect(res.fileName).toEqual('gitlab-import-targets.json');

--- a/test/system/__snapshots__/import:data.test.ts.snap
+++ b/test/system/__snapshots__/import:data.test.ts.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`\`snyk-api-import import:data <...>\` Shows error when missing  1`] = `
+[Error: Command failed: node ./dist/index.js import:data --source=github
+index.js import:data
+
+Generate data required for targets to be imported via API to create Snyk
+projects.
+
+
+Options:
+  --version          Show version number                               [boolean]
+  --help             Show help                                         [boolean]
+  --orgsData         Path to organizations data file generated with "orgs:data"
+                     command                                          [required]
+  --source           The source of the targets to be imported e.g. Github,
+                     Github Enterprise, Gitlab. This will be used to make an API
+                     call to list all available entities per org
+         [required] [choices: "github", "github-enterprise", "gitlab"] [default:
+                                                                       "github"]
+  --sourceUrl        Custom base url for the source API that can list
+                     organizations (e.g. Github Enterprise url)
+  --integrationType  The configured integration type on the created Snyk Org to
+                     use for generating import targets data. Applies to all
+                     targets.
+                   [required] [choices: "github", "github-enterprise", "gitlab"]
+
+Missing required arguments: orgsData, integrationType
+]
+`;
+
+exports[`\`snyk-api-import import:data <...>\` Shows error when missing  2`] = `
+"index.js import:data
+
+Generate data required for targets to be imported via API to create Snyk
+projects.
+
+
+Options:
+  --version          Show version number                               [boolean]
+  --help             Show help                                         [boolean]
+  --orgsData         Path to organizations data file generated with \\"orgs:data\\"
+                     command                                          [required]
+  --source           The source of the targets to be imported e.g. Github,
+                     Github Enterprise, Gitlab. This will be used to make an API
+                     call to list all available entities per org
+         [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\"] [default:
+                                                                       \\"github\\"]
+  --sourceUrl        Custom base url for the source API that can list
+                     organizations (e.g. Github Enterprise url)
+  --integrationType  The configured integration type on the created Snyk Org to
+                     use for generating import targets data. Applies to all
+                     targets.
+                   [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\"]
+
+Missing required arguments: orgsData, integrationType
+"
+`;
+
+exports[`\`snyk-api-import import:data <...>\` Shows help text as expected 1`] = `
+"index.js import:data
+
+Generate data required for targets to be imported via API to create Snyk
+projects.
+
+
+Options:
+  --version          Show version number                               [boolean]
+  --help             Show help                                         [boolean]
+  --orgsData         Path to organizations data file generated with \\"orgs:data\\"
+                     command                                          [required]
+  --source           The source of the targets to be imported e.g. Github,
+                     Github Enterprise, Gitlab. This will be used to make an API
+                     call to list all available entities per org
+         [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\"] [default:
+                                                                       \\"github\\"]
+  --sourceUrl        Custom base url for the source API that can list
+                     organizations (e.g. Github Enterprise url)
+  --integrationType  The configured integration type on the created Snyk Org to
+                     use for generating import targets data. Applies to all
+                     targets.
+                   [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\"]"
+`;

--- a/test/system/fixtures/org-data/orgs.json
+++ b/test/system/fixtures/org-data/orgs.json
@@ -1,0 +1,11 @@
+{
+  "orgData": [
+    {
+      "name": "snyk-fixtures",
+      "orgId": "<snyk_org_id>",
+      "integrations": {
+        "gitlab": "<snyk_org_integration_id>"
+      }
+    }
+  ]
+}

--- a/test/system/help.test.ts
+++ b/test/system/help.test.ts
@@ -11,11 +11,12 @@ describe('`snyk-api-import help <...>`', () => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {
-    exec(`node ${main} help`, (err, stdout) => {
+    exec(`node ${main} help`, (err, stdout, stderr) => {
       if (err) {
         throw err;
       }
       expect(err).toBeNull();
+      expect(stderr).toEqual('');
       expect(stdout.trim()).toMatchSnapshot();
       done();
     });

--- a/test/system/help.test.ts
+++ b/test/system/help.test.ts
@@ -11,7 +11,7 @@ describe('`snyk-api-import help <...>`', () => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {
-    return exec(`node ${main} help`, (err, stdout) => {
+    exec(`node ${main} help`, (err, stdout) => {
       if (err) {
         throw err;
       }

--- a/test/system/import.test.ts
+++ b/test/system/import.test.ts
@@ -36,10 +36,11 @@ describe('`snyk-api-import import`', () => {
           ORG_ID: process.env.TEST_ORG_ID
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
+        expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout.trim()).toMatch(`project(s)
 Processed 1 out of a total of 1 targets
@@ -68,11 +69,12 @@ Check the logs for any failures located at:`);
           ORG_ID: process.env.TEST_ORG_ID
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
         expect(err).toBeNull();
+        expect(stderr).toEqual('');
         expect(stdout.trim()).toMatch(`project(s)
 Processed 1 out of a total of 1 targets
 Check the logs for any failures located at:`);

--- a/test/system/import.test.ts
+++ b/test/system/import.test.ts
@@ -24,7 +24,7 @@ describe('`snyk-api-import import`', () => {
 
     const importFile = path.resolve(testRoot + '/import-projects-single.json');
     const logPath = path.resolve(testRoot);
-    return exec(
+    exec(
       `node ${main}`,
       {
         env: {
@@ -56,7 +56,7 @@ Check the logs for any failures located at:`);
     const importFile = path.resolve(testRoot + '/import-projects.json');
     const logPath = path.resolve(testRoot);
 
-    return exec(
+    exec(
       `node ${main} import`,
       {
         env: {

--- a/test/system/import:data.test.ts
+++ b/test/system/import:data.test.ts
@@ -1,16 +1,16 @@
 import { exec } from 'child_process';
-import { sep } from 'path';
+import { sep, join } from 'path';
 import { deleteFiles } from '../delete-files';
 const main = './dist/index.js'.replace(/\//g, sep);
 
-describe('`snyk-api-import orgs:data <...>`', () => {
+describe('`snyk-api-import import:data <...>`', () => {
   const OLD_ENV = process.env;
   afterAll(async () => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {
     exec(
-      `node ${main} orgs:data help`,
+      `node ${main} import:data help`,
       {
         env: {
           PATH: process.env.PATH,
@@ -18,42 +18,45 @@ describe('`snyk-api-import orgs:data <...>`', () => {
           SNYK_LOG_PATH: __dirname,
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
         expect(err).toBeNull();
+        expect(stderr).toEqual('');
         expect(stdout.trim()).toMatchSnapshot();
         done();
       },
     );
   });
 
-  it('Generates orgs data as expected', (done) => {
-    const groupId = 'hello';
+  it('Generates repo data as expected for Gitlab', (done) => {
+    const orgDataFile = 'test/system/fixtures/org-data/orgs.json';
     exec(
-      `node ${main} orgs:data --source=github --groupId=${groupId}`,
+      `node ${main} import:data --source=gitlab --integrationType=gitlab --sourceUrl=${process.env.TEST_GITLAB_BASE_URL} --orgsData=${orgDataFile}`,
       {
         env: {
           PATH: process.env.PATH,
-          GITHUB_TOKEN: process.env.GH_TOKEN,
+          GITLAB_TOKEN: process.env.TEST_GITLAB_TOKEN,
           SNYK_LOG_PATH: __dirname,
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
         expect(err).toBeNull();
-        expect(stdout.trim()).toMatchSnapshot();
-        deleteFiles([`group-${groupId}-github-com-orgs.json`]);
+        expect(stderr).toEqual('');
+        expect(stdout.trim()).toMatch('Written the data to file');
+        deleteFiles([join(__dirname, 'gitlab-import-targets.json')]);
         done();
       },
     );
   }, 20000);
-  it('Shows error when missing groupId', (done) => {
-    exec(`node ${main} orgs:data --source=github`, (err, stdout) => {
+  it('Shows error when missing ', (done) => {
+    exec(`node ${main} import:data --source=github`, (err, stdout, stderr) => {
       expect(err).toMatchSnapshot();
+      expect(stderr).toMatchSnapshot();
       expect(stdout).toEqual('');
       done();
     });

--- a/test/system/list:imported.test.ts
+++ b/test/system/list:imported.test.ts
@@ -15,7 +15,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {
-    return exec(`node ${main} list:imported help`, (err, stdout) => {
+    exec(`node ${main} list:imported help`, (err, stdout) => {
       if (err) {
         throw err;
       }
@@ -26,7 +26,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
   });
 
   it('Generates Snyk imported targets data as expected for github + Group', (done) => {
-    return exec(
+    exec(
       `node ${main} list:imported --integrationType=github --groupId=${GROUP_ID}`,
       {
         env: {
@@ -54,7 +54,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
   }, 20000);
 
   it('Generates Snyk imported targets data as expected for all integrations by default for an Org', (done) => {
-    return exec(
+    exec(
       `node ${main} list:imported --orgId=${ORG_ID}`,
       {
         env: {
@@ -82,7 +82,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
   }, 10000);
 
   it('Generates Snyk imported targets data as expected for multiple integrations for an Org', (done) => {
-    return exec(
+    exec(
       `node ${main} list:imported --integrationType=github --integrationType=github-enterprise --orgId=${ORG_ID}`,
       {
         env: {
@@ -110,7 +110,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
   }, 10000);
 
   it('Generates Snyk imported targets data as expected for an Org', (done) => {
-    return exec(
+    exec(
       `node ${main} list:imported --integrationType=github --orgId=${ORG_ID}`,
       {
         env: {
@@ -137,7 +137,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
     );
   }, 10000);
   it('Shows error when missing groupId & orgId', (done) => {
-    return exec(
+    exec(
       `node ${main} list:imported --integrationType=github`,
       {
         env: {
@@ -158,7 +158,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
     );
   });
   it('Shows error when missing groupId & orgId', (done) => {
-    return exec(
+    exec(
       `node ${main} list:imported --integrationType=github --orgId=foo --groupId=bar`,
       {
         env: {

--- a/test/system/list:imported.test.ts
+++ b/test/system/list:imported.test.ts
@@ -36,10 +36,11 @@ describe('`snyk-api-import list:imported <...>`', () => {
           SNYK_LOG_PATH: __dirname,
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
+        expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout.trim()).toMatch(
           `repo(s). Written the data to file: ${path.resolve(
@@ -64,10 +65,11 @@ describe('`snyk-api-import list:imported <...>`', () => {
           SNYK_LOG_PATH: __dirname,
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
+        expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout.trim()).toMatch(
           `target(s). Written the data to file: ${path.resolve(
@@ -92,10 +94,11 @@ describe('`snyk-api-import list:imported <...>`', () => {
           SNYK_LOG_PATH: __dirname,
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
+        expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout.trim()).toMatch(
           `target(s). Written the data to file: ${path.resolve(
@@ -120,10 +123,11 @@ describe('`snyk-api-import list:imported <...>`', () => {
           SNYK_LOG_PATH: __dirname,
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
+        expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout.trim()).toMatch(
           `repo(s). Written the data to file: ${path.resolve(

--- a/test/system/orgs:create.test.ts
+++ b/test/system/orgs:create.test.ts
@@ -9,7 +9,7 @@ describe('`snyk-api-import help <...>`', () => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {
-    return exec(`node ${main} orgs:create help`, (err, stdout) => {
+    exec(`node ${main} orgs:create help`, (err, stdout) => {
       if (err) {
         throw err;
       }
@@ -26,7 +26,7 @@ describe('`snyk-api-import help <...>`', () => {
       __dirname + '/fixtures/create-orgs/fails-to-create/',
     );
 
-    return exec(
+    exec(
       `node ${main} orgs:create --file=${pathToBadJson}`,
       {
         env: {
@@ -55,7 +55,7 @@ describe('`snyk-api-import help <...>`', () => {
     const logPath = path.resolve(
       __dirname + '/fixtures/create-orgs/fails-to-create/',
     );
-    return exec(
+    exec(
       `node ${main} orgs:create --file=${pathToBadJson} --noDuplicateNames`,
       {
         env: {

--- a/test/system/orgs:data.test.ts
+++ b/test/system/orgs:data.test.ts
@@ -18,10 +18,11 @@ describe('`snyk-api-import orgs:data <...>`', () => {
           SNYK_LOG_PATH: __dirname,
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
+        expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout.trim()).toMatchSnapshot();
         done();
@@ -40,10 +41,11 @@ describe('`snyk-api-import orgs:data <...>`', () => {
           SNYK_LOG_PATH: __dirname,
         },
       },
-      (err, stdout) => {
+      (err, stdout, stderr) => {
         if (err) {
           throw err;
         }
+        expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout.trim()).toMatchSnapshot();
         deleteFiles([`group-${groupId}-github-com-orgs.json`]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "sourceMap": true,
     "declaration": true,
     "importHelpers": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/**/*"]
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

- Add suport for Gitlab projects to be listed given a Group
- Generate the targets data needed for Snyk to import the projects

### Notes for the reviewer
Support for generating Gitlab Import data, docs to read & review https://github.com/snyk-tech-services/snyk-api-import/blob/2731790dcda3e97e226cc59a32d97e52e43f4cec/docs/import-data.md