### PR TITLE
feat: support listing all available Gitlab Groups

### DIFF
--- a/docs/import-data.md
+++ b/docs/import-data.md
@@ -10,7 +10,7 @@ This is a util that can help generate the import json data needed by the import 
 
 
 # `import:data`
-### Github.com / Github Enterprise
+## Github.com / Github Enterprise
 1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
 2. You will need to have the organizations data in json as an input to this command to help map Snyk organization IDs and Integration Ids that must be used during import against individual targets to be imported. The following format is required:
   ```
@@ -40,7 +40,7 @@ This is a util that can help generate the import json data needed by the import 
 
 4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
 
-### Gitlab.com / Hosted Gitlab
+## Gitlab.com / Hosted Gitlab
 1. set the [Gitlab personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) as an environment variable: `export GITLAB_TOKEN=your_personal_access_token`
 2. You will need to have the organizations data in json as an input to this command to help map Snyk organization IDs and Integration Ids that must be used during import against individual targets to be imported. The following format is required:
   ```

--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -1,16 +1,23 @@
 # Creating Organizations in Snyk
 
+## Table of Contents
+- Generating the data to create Organizations in Snyk
+  - [Github](#githubcom--github-enterprise)
+  - [Gitlab](#gitlabcom--hosted-gitlab)
+- [Creating the organizations](#creating-organizations-in-snyk-1)
+  - [via the API](#via-api)
+  - [via the `orgs:create` util](#via-orgscreate-util)
+- [Recommendations](#recommendations)
+
 Before an import can begin Snyk needs to be setup with the Organizations you will populate with projects.
 
 It is recommended to have as many Organizations in Snyk as you have in the source you are importing from. So for Github this would mean mirroring the Github organizations in Snyk. The tool provides a utility that can be used to make this simpler when using Groups & Organizations in Snyk.
 
-## Generating the data required to create Organizations in Snyk
-
-### using `orgs:data` util
+# Generating the data required to create Organizations in Snyk with `orgs:data` util
 This util helps generate data needed to mirror the Github.com / Github Enterprise organization structure in Snyk.
 This is an opinionated util and will assume every organization in Github.com / Github Enterprise should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
 
-#### Github.com / Github Enterprise
+## Github.com / Github Enterprise
 1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
 2. Run the command to generate organization data:
  - **Github.com:** `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id>`
@@ -18,12 +25,21 @@ This is an opinionated util and will assume every organization in Github.com / G
 
 This will create the organization data in a file `group-<snyk_group_id>-github-<com|enterprise>-orgs.json`
 
-## Creating Organizations in Snyk
+
+## Gitlab.com / Hosted Gitlab
+1. set the [Gitlab personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) as an environment variable: `export GITLAB_TOKEN=your_personal_access_token`
+2. Run the command to generate organization data:
+ - **Gitlab:** `snyk-api-import orgs:data --source=gitlab --groupId=<snyk_group_id>`
+ - **Hosted Gitlab:** `snyk-api-import orgs:data --source=gitlab --groupId=<snyk_group_id> -- sourceUrl=https://gitlab.custom.com`
+
+This will create the organization data in a file `group-<snyk_group_id>-gitlab-orgs.json`
+
+# Creating Organizations in Snyk
 Use the generated data file to help create the organizations via API or use the provided util.
-### via API
+## via API
 Use the generated data to feed into Snyk [Orgs API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) to generate the organizations within a group.
 
-### via `orgs:create` util
+## via `orgs:create` util
 1. set the `SNYK_TOKEN` environment variable - your [Snyk api token](https://app.snyk.io/account)
 2. Run the command to create Orgs:
 `snyk-api-import orgs:create --file=group-<snyk_group_id>-github-<com|enterprise>-orgs.json`

--- a/src/lib/source-handlers/github/organization-is-empty.ts
+++ b/src/lib/source-handlers/github/organization-is-empty.ts
@@ -14,7 +14,7 @@ export async function githubOrganizationIsEmpty(
   const githubToken = getGithubToken();
   const baseUrl = getGithubBaseUrl(host);
   const octokit: Octokit = new Octokit({ baseUrl, auth: githubToken });
-  debug(`Fetching all repos data for org: ${orgName}`);
+  debug(`Fetching 1 page of repos data for org: ${orgName}`);
   const perPage = 1;
   const { repos } = await fetchReposForPage(octokit, orgName, undefined, perPage);
   if (!repos || repos.length === 0) {

--- a/src/lib/source-handlers/gitlab/group-is-empty.ts
+++ b/src/lib/source-handlers/gitlab/group-is-empty.ts
@@ -1,0 +1,24 @@
+import { Gitlab } from '@gitbeaker/node';
+
+import * as debugLib from 'debug';
+import { fetchGitlabReposForPage } from './list-repos';
+import { getBaseUrl } from './get-base-url';
+import { getToken } from './get-token';
+
+const debug = debugLib('snyk:github');
+
+export async function gitlabGroupIsEmpty(
+  groupName: string,
+  host?: string,
+): Promise<boolean> {
+  const token = getToken();
+  const baseUrl = getBaseUrl(host);
+  const client = new Gitlab({ host: baseUrl, token });
+  debug(`Fetching 1 page of projects data for group: ${groupName}`);
+  const perPage = 1;
+  const { repos } = await fetchGitlabReposForPage(client, groupName, undefined, perPage);
+  if (!repos || repos.length === 0) {
+    return true;
+  }
+  return false;
+}

--- a/src/lib/source-handlers/gitlab/index.ts
+++ b/src/lib/source-handlers/gitlab/index.ts
@@ -1,2 +1,4 @@
 export { listGitlabRepos } from './list-repos';
-export  * from './types';
+export * from './list-groups';
+export * from './group-is-empty';
+export * from './types';

--- a/src/lib/source-handlers/gitlab/list-groups.ts
+++ b/src/lib/source-handlers/gitlab/list-groups.ts
@@ -1,0 +1,71 @@
+import * as debugLib from 'debug';
+import { Gitlab } from '@gitbeaker/node';
+import * as types from '@gitbeaker/core/dist/types';
+
+import { getToken } from './get-token';
+import { getBaseUrl } from './get-base-url';
+import { GitlabGroupData } from './types';
+
+const debug = debugLib('snyk:github');
+
+async function fetchOrgsForPage(
+  client: types.Gitlab,
+  pageNumber = 1,
+): Promise<{
+  orgs: GitlabGroupData[];
+  hasNextPage: boolean;
+}> {
+  const orgsData: GitlabGroupData[] = [];
+  const params = {
+    perPage: 100,
+    page: pageNumber,
+  };
+  let hasNextPage;
+
+  const orgs = await client.Groups.all(params);
+  if (orgs.length) {
+    hasNextPage = true;
+
+    orgsData.push(
+      ...orgs.map((org: any) => ({
+        name: org.name,
+        id: org.id,
+        url: org.web_url,
+      })),
+    );
+  } else {
+    hasNextPage = false;
+  }
+  return {
+    orgs: orgsData,
+    hasNextPage,
+  };
+}
+
+async function fetchAllOrgs(
+  client: types.Gitlab,
+  page = 0,
+): Promise<GitlabGroupData[]> {
+  const orgsData: GitlabGroupData[] = [];
+  let currentPage = page;
+  let hasMorePages = true;
+  while (hasMorePages) {
+    currentPage = currentPage + 1;
+    debug(`Fetching page ${currentPage}`);
+    const { orgs, hasNextPage } = await fetchOrgsForPage(client, currentPage);
+    orgsData.push(...orgs);
+    hasMorePages = hasNextPage;
+  }
+  return orgsData;
+}
+
+export async function listGitlabGroups(
+  host?: string,
+): Promise<GitlabGroupData[]> {
+  const token = getToken();
+  const baseUrl = getBaseUrl(host);
+  const client = new Gitlab({ host: baseUrl, token });
+  debug(`Fetching all Gitlab groups data from ${baseUrl}`);
+  const orgs = await fetchAllOrgs(client);
+  return orgs;
+}

--- a/src/lib/source-handlers/gitlab/types.ts
+++ b/src/lib/source-handlers/gitlab/types.ts
@@ -4,3 +4,9 @@ export interface GitlabRepoData {
   id: number;
   name: string;
 }
+
+export interface GitlabGroupData {
+  name: string;
+  id: number;
+  url: string;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,6 +83,7 @@ export enum SupportedIntegrationTypesImportData {
 export enum SupportedIntegrationTypesImportOrgData {
   GITHUB = 'github',
   GHE = 'github-enterprise',
+  GITLAB = 'gitlab',
 }
 
 // used to generate imported targets that exist in Snyk
@@ -92,7 +93,7 @@ export enum SupportedIntegrationTypesToListSnykTargets {
   GHE = 'github-enterprise',
   BITBUCKET_CLOUD = 'bitbucket-cloud',
   GCR = 'gcr',
-  DOCKER_HUB = 'docker-hub'
+  DOCKER_HUB = 'docker-hub',
 }
 interface ImportingUser {
   id: string;

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -5,6 +5,7 @@ import {
   githubOrganizations,
   SnykOrgData,
 } from '../lib/source-handlers/github';
+import { listGitlabGroups, gitlabGroupIsEmpty } from '../lib/source-handlers/gitlab';
 import {
   CreateOrgData,
   SupportedIntegrationTypesImportOrgData,
@@ -12,6 +13,7 @@ import {
 import { writeFile } from '../write-file';
 
 const sourceGenerators = {
+  [SupportedIntegrationTypesImportOrgData.GITLAB]: listGitlabGroups,
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizations,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubEnterpriseOrganizations,
 };
@@ -19,6 +21,7 @@ const sourceGenerators = {
 const sourceNotEmpty = {
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizationIsEmpty,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubOrganizationIsEmpty,
+  [SupportedIntegrationTypesImportOrgData.GITLAB]: gitlabGroupIsEmpty,
 };
 
 export const entityName: {
@@ -26,6 +29,15 @@ export const entityName: {
 } = {
   github: 'organization',
   'github-enterprise': 'organization',
+  gitlab: 'group',
+};
+
+const exportFileName: {
+  [source in SupportedIntegrationTypesImportOrgData]: string;
+} = {
+  github: 'github-com',
+  'github-enterprise': 'github-enterprise',
+  gitlab: 'gitlab',
 };
 
 export async function generateOrgImportDataFile(
@@ -69,9 +81,7 @@ export async function generateOrgImportDataFile(
     { concurrency: 10 },
   );
 
-  const fileName = `group-${groupId}-${
-    sourceUrl ? 'github-enterprise' : 'github-com'
-  }-orgs.json`;
+  const fileName = `group-${groupId}-${exportFileName[source]}-orgs.json`;
   await writeFile(fileName, ({
     orgs: orgData,
   } as unknown) as JSON);

--- a/test/lib/source-handlers/gitlab/list-groups.test.ts
+++ b/test/lib/source-handlers/gitlab/list-groups.test.ts
@@ -1,0 +1,21 @@
+import { listGitlabGroups } from '../../../../src/lib/source-handlers/gitlab/list-groups';
+
+describe('listGitlabGroups', () => {
+  const OLD_ENV = process.env;
+
+  afterEach(async () => {
+    process.env = { ...OLD_ENV };
+  });
+  it('list repos (Gitlab Custom URL)', async () => {
+    const GITLAB_BASE_URL = process.env.TEST_GITLAB_BASE_URL;
+    process.env.GITLAB_TOKEN = process.env.TEST_GITLAB_TOKEN;
+
+    const groups = await listGitlabGroups(GITLAB_BASE_URL);
+    expect(groups.length >= 1).toBeTruthy();
+    expect(groups[0]).toEqual({
+      name: expect.any(String),
+      id: expect.any(Number),
+      url: expect.any(String),
+    });
+  });
+});

--- a/test/system/__snapshots__/orgs:data.test.ts.snap
+++ b/test/system/__snapshots__/orgs:data.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`\`snyk-api-import orgs:data <...>\` Generates orgs data as expected 1`] = `"Found 9 organization(s). Written the data to file: group-hello-github-com-orgs.json"`;
 
+exports[`\`snyk-api-import orgs:data <...>\` Generates orgs data as expected for Gitlab 1`] = `"Found 14 group(s). Written the data to file: group-hello-gitlab-orgs.json"`;
+
 exports[`\`snyk-api-import orgs:data <...>\` Shows error when missing groupId 1`] = `
 [Error: Command failed: node ./dist/index.js orgs:data --source=github
 index.js orgs:data

--- a/test/system/orgs:data.test.ts
+++ b/test/system/orgs:data.test.ts
@@ -53,6 +53,29 @@ describe('`snyk-api-import orgs:data <...>`', () => {
       },
     );
   }, 20000);
+  it('Generates orgs data as expected for Gitlab', (done) => {
+    const groupId = 'hello';
+    exec(
+      `node ${main} orgs:data --source=gitlab --groupId=${groupId} --sourceUrl=${process.env.TEST_GITLAB_BASE_URL}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          GITLAB_TOKEN: process.env.TEST_GITLAB_TOKEN,
+          SNYK_LOG_PATH: __dirname,
+        },
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          throw err;
+        }
+        expect(stderr).toEqual('');
+        expect(err).toBeNull();
+        expect(stdout.trim()).toMatchSnapshot();
+        deleteFiles([`group-${groupId}-gitlab-orgs.json`]);
+        done();
+      },
+    );
+  }, 20000);
   it('Shows error when missing groupId', (done) => {
     exec(`node ${main} orgs:data --source=github`, (err, stdout) => {
       expect(err).toMatchSnapshot();


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

List all Groups in Gitlab and transform the data to the format needed for Snyk to create the organizations. This is part of the `mirror` workflow have the same structure in Snyk as in Gitlab where:
- Gitlab Group = Snyk Organization
- Gitlab Project within the group = Snyk Project within the group

### Notes for the reviewer
Docs: https://github.com/snyk-tech-services/snyk-api-import/blob/b1b29396114f76f27d49527d41af91b1f3d7baed/docs/orgs.md