### PR TITLE
feat: improve import file location

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -3,7 +3,7 @@ Any logs will be generated at `SNYK_LOG_PATH` directory.
 
 ### 1. Create the `import-projects.json` file
 
-The file is expected to have a **required** `targets` top level key which is an array of **import targets**. 
+The file is expected to have a **required** `targets` top level key which is an array of **import targets**.
 ```
 {
   targets: [
@@ -20,9 +20,9 @@ Each **import target** has the following keys:
   "orgId": "<public_snyk_org_id>",
   "integrationId": <"public_snyk_integration_id>",
   "target": {..} // the identifier of where the projects can be found (for example branch, repo name and owner for Github)
-   
+
    // optional
-  "files": [ "full/path/to/file1", "full/path/to/file2"], 
+  "files": [ "full/path/to/file1", "full/path/to/file2"],
   "exclusionGlobs": "fixtures, tests, __tests__, node_modules",
 }
 ```
@@ -34,7 +34,7 @@ Each **import target** has the following keys:
 
 
 
-  *Note*: For a repo that may have 200+ manifest files it is recommended to split this import into multiple by targeting specific files. Importing hundreds of files at once from 1 repo can cause the import to result in some errors/failures. 
+  *Note*: For a repo that may have 200+ manifest files it is recommended to split this import into multiple by targeting specific files. Importing hundreds of files at once from 1 repo can cause the import to result in some errors/failures.
 
 Splitting it to target some files, or some folders only will benefit from the re-tries and yield a smaller load on the source control management system being used. Populate the the `files` property to accomplish this in the import JSON.
 
@@ -131,14 +131,14 @@ Splitting it to target some files, or some folders only will benefit from the re
 }
 ```
 ### 2. Set the env vars:
-  - `SNYK_IMPORT_PATH`- the path to the import file
+  - `SNYK_IMPORT_PATH`- the path to the import file or use `--file` parameter
   - `SNYK_TOKEN` - your [Snyk api token](https://app.snyk.io/account)
   - `SNYK_LOG_PATH` - the path to folder where all logs should be saved,it is recommended creating a dedicated logs folder per import you have running. (Note: all logs will append)
   - `CONCURRENT_IMPORTS` (optional) defaults to 15 repos at a time, which is the recommended amount to import at once as a max.  Just 1 repo may have many projects inside which can trigger a many files at once to be requested from the user's SCM instance and some may have rate limiting in place. This script aims to help reduce the risk of hitting a rate limit.
   - `SNYK_API` (optional) defaults to `https://snyk.io/api/v1`
 
 ### 3. Download & run
-Grab a binary from the [releases page](https://github.com/snyk-tech-services/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos`
+Grab a binary from the [releases page](https://github.com/snyk-tech-services/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos import --file=path/to/imported-targets.json`
 
 ## To skip all previously imported targets
 This can be used to skip previously imported targets (repos) so only remaining targets will be imported.

--- a/src/cmds/import.ts
+++ b/src/cmds/import.ts
@@ -9,13 +9,22 @@ import { getLoggingPath } from '../lib';
 
 export const command = ['import', '$0'];
 export const desc = 'Kick off API powered import';
-export const builder = {};
+export const builder = {
+  file: {
+    required: false,
+    default: 'import-projects.json',
+    desc: 'Path to json file that contains the targets to be imported',
+  },
+};
+
 export const aliases = ['i'];
 
-export async function handler(): Promise<void> {
+export async function handler(argv: { file: string }): Promise<void> {
   try {
+    const { file } = argv;
+    debug('ℹ️  Options: ' + JSON.stringify(argv));
     const logsPath = getLoggingPath();
-    const importFile = getImportProjectsFile();
+    const importFile = getImportProjectsFile(file);
     const {
       projects,
       filteredTargets,
@@ -24,12 +33,12 @@ export async function handler(): Promise<void> {
     } = await importProjects(importFile);
     const projectsMessage =
       projects.length > 0
-        ? `Imported ${ _.uniqBy(projects, 'projectUrl').length} project(s)`
+        ? `Imported ${_.uniqBy(projects, 'projectUrl').length} project(s)`
         : '⚠ No projects imported!';
 
-    const targetsMessage = `\nProcessed ${filteredTargets.length} out of a total of ${
-      targets.length
-    } targets${
+    const targetsMessage = `\nProcessed ${
+      filteredTargets.length
+    } out of a total of ${targets.length} targets${
       skippedTargets
         ? ` (${skippedTargets} were skipped as they have been previously imported).`
         : ''
@@ -42,6 +51,9 @@ export async function handler(): Promise<void> {
     );
   } catch (e) {
     debug('Failed to kick off import.\n' + e);
-    console.error('ERROR! Failed to kick off import. Try running with `DEBUG=snyk* snyk-import`');
+    console.error(
+      `ERROR! Failed to kick off import with error:
+      ${e.message}\n Try running with \`DEBUG=snyk* snyk-import\` for more information`,
+    );
   }
 }

--- a/src/lib/get-import-path.ts
+++ b/src/lib/get-import-path.ts
@@ -1,9 +1,37 @@
-export function getImportProjectsFile(): string {
-  const snykImportPath = process.env.SNYK_IMPORT_PATH;
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function getImportProjectsFile(filePath?: string): string {
+  const snykImportPath = filePath || process.env.SNYK_IMPORT_PATH;
   if (!snykImportPath) {
     throw new Error(
-      `Please set the SNYK_IMPORT_PATH e.g. export SNYK_IMPORT_PATH='~/my/path/to/file'`,
+      `Please set the SNYK_IMPORT_PATH environment variable (for example export SNYK_IMPORT_PATH='~/my/path/to/file') or set it with --file='~/my/path/to/file'`,
     );
   }
-  return snykImportPath;
+
+  const { ext, base } = path.parse(snykImportPath);
+  const jsonFileName = ext === '.json' ? base : undefined;
+
+  if (jsonFileName) {
+    const absolutePath = path.resolve(process.cwd(), snykImportPath);
+    // if it looks like a path to file return the path
+    if (fs.existsSync(absolutePath)) {
+      return absolutePath;
+    }
+  }
+
+  // if it looks like a directory
+  // assume file name
+  const defaultFile = path.resolve(
+    process.cwd(),
+    snykImportPath,
+    'import-projects.json',
+  );
+  if (fs.existsSync(defaultFile)) {
+    return defaultFile;
+  }
+
+  throw new Error(
+    `Please set the SNYK_IMPORT_PATH e.g. export SNYK_IMPORT_PATH='~/my/path/to/import-projects.json'`,
+  );
 }

--- a/test/lib/fixtures/single-project/import-projects-single.json
+++ b/test/lib/fixtures/single-project/import-projects-single.json
@@ -1,0 +1,13 @@
+{
+  "targets": [
+    {
+      "orgId": "74e2f385-a54f-491e-9034-76c53e72927a",
+      "integrationId": "a8a32129-ed31-45dd-b95e-e46f64025d43",
+      "target": {
+        "name": "ruby-with-versions",
+        "owner": "snyk-fixtures",
+        "branch": "master"
+      }
+    }
+  ]
+}

--- a/test/lib/fixtures/single-project/import-projects.json
+++ b/test/lib/fixtures/single-project/import-projects.json
@@ -1,0 +1,13 @@
+{
+  "targets": [
+    {
+      "orgId": "74e2f385-a54f-491e-9034-76c53e72927a",
+      "integrationId": "a8a32129-ed31-45dd-b95e-e46f64025d43",
+      "target": {
+        "name": "ruby-with-versions",
+        "owner": "snyk-fixtures",
+        "branch": "master"
+      }
+    }
+  ]
+}

--- a/test/lib/get-import-path.spec.ts
+++ b/test/lib/get-import-path.spec.ts
@@ -1,0 +1,53 @@
+import * as path from 'path';
+import { getImportProjectsFile } from '../../src/lib/get-import-path';
+
+describe('getImportProjectsFile', () => {
+  const OLD_ENV = process.env;
+  afterEach(async () => {
+    process.env = { ...OLD_ENV };
+  });
+
+  it('Full path resolves OK', () => {
+    delete process.env.SNYK_IMPORT_PATH;
+    const filePath = path.resolve(
+      __dirname + '/fixtures/single-project/import-projects-single.json',
+    );
+    const pathToJsonFile = getImportProjectsFile(filePath);
+    expect(pathToJsonFile).toMatch(
+      '/fixtures/single-project/import-projects-single.json',
+    );
+  });
+
+  it('Full path provided via env var resolves OK', () => {
+    process.env.SNYK_IMPORT_PATH = path.resolve(
+      __dirname + '/fixtures/single-project/import-projects-single.json',
+    );
+    const pathToJsonFile = getImportProjectsFile();
+    expect(pathToJsonFile).toMatch(
+      '/fixtures/single-project/import-projects-single.json',
+    );
+  });
+
+  it('Relative path resolves ok', () => {
+    const pathToJsonFile = getImportProjectsFile(
+      './test/lib/fixtures/single-project/import-projects-single.json',
+    );
+    expect(pathToJsonFile).toMatch(
+      '/fixtures/single-project/import-projects-single.json',
+    );
+  });
+
+  it('Missing file name assumes: import-projects.json', () => {
+    const filePath = path.resolve(__dirname + '/fixtures/single-project');
+    const pathToJsonFile = getImportProjectsFile(filePath);
+    expect(pathToJsonFile).toMatch(
+      '/fixtures/single-project/import-projects.json',
+    );
+  });
+
+  it('If path / file does not exist throws error', () => {
+    expect(() => {
+      getImportProjectsFile('/fixtures/non-existent.json');
+    }).toThrow('Please set the SNYK_IMPORT_PATH e.g. export SNYK_IMPORT_PATH=\'~/my/path/to/import-projects.json\'');
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Support absolute and relative path to the import file,
if only a folder path is provided assume a default file name
Allow users to provide the path via --file param as well as the
env variable


https://github.com/snyk-tech-services/snyk-api-import/issues/192