### PR TITLE
fix: forward on full JSON.parse error to user

### DIFF
--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -118,7 +118,9 @@ export async function importProjects(
   try {
     targets.push(...JSON.parse(content).targets);
   } catch (e) {
-    throw new Error(`Failed to parse targets from ${fileName}`);
+    throw new Error(
+      `Failed to parse targets from ${fileName}:\n${e.message}`,
+    );
   }
   console.log(
     `Loaded ${targets.length} target(s) to import | ${new Date(

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -200,6 +200,7 @@ describe('Error handling', () => {
   const OLD_ENV = process.env;
   process.env.SNYK_API = SNYK_API_TEST;
   process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+  process.env.SNYK_LOG_PATH = __dirname;
 
   afterAll(async () => {
     process.env = { ...OLD_ENV };
@@ -211,11 +212,12 @@ describe('Error handling', () => {
     ).rejects.toThrow('File can not be found at location');
   }, 300);
   it('shows correct error when input is invalid json', async () => {
-    expect(
-      importProjects(
-        path.resolve(__dirname + '/fixtures/import-projects-invalid.json'),
-      ),
-    ).rejects.toThrow('Failed to parse targets from');
+    const file = path.resolve(
+      __dirname + '/fixtures/import-projects-invalid.json',
+    );
+    expect(importProjects(file)).rejects.toThrow(
+      `Failed to parse targets from ${file}:\nUnexpected token } in JSON at position 120`,
+    );
   }, 300);
 
   it('shows correct error when SNYK_LOG_PATH is not set', async () => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Rather than just display "Failed to parse targets from <file>" also
include the JSON.parse error message to help detect where the issue is
