### PR TITLE
fix: use Gitlab path not name from Groups API

### DIFF
--- a/src/lib/source-handlers/gitlab/list-groups.ts
+++ b/src/lib/source-handlers/gitlab/list-groups.ts
@@ -28,7 +28,7 @@ async function fetchOrgsForPage(
 
     orgsData.push(
       ...orgs.map((org: any) => ({
-        name: org.name,
+        name: org.path,
         id: org.id,
         url: org.web_url,
       })),


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Gitlabs Group name and slug can be very different, use the slug since it is needed to make all the API calls. This will also keep the org names = Gitlab slug in Snyk. 