### PR TITLE
fix: reduce # of repos request to avoid Github 500 error

### DIFF
--- a/src/lib/source-handlers/github/list-repos.ts
+++ b/src/lib/source-handlers/github/list-repos.ts
@@ -11,7 +11,7 @@ export async function fetchReposForPage(
   octokit: Octokit,
   orgName: string,
   pageNumber = 1,
-  perPage = 100,
+  perPage = 50,
 ): Promise<{
   repos: GithubRepoData[];
   hasNextPage: boolean;
@@ -64,7 +64,7 @@ async function fetchAllRepos(
       hasMorePages = hasNextPage;
       repoData.push(...repos);
     } catch (e) {
-      if (e.status === 403) {
+      if (e.status === 403 || e.status >= 500) {
         const sleepTime = 120000; // 2 mins
         console.error(`Sleeping for ${sleepTime} ms`);
         await new Promise((r) => setTimeout(r, sleepTime));


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Github is throwing 500s even when requesting 1 page at a time,
retry the request after a sleep + reduce # of repos requested at once
