### PR TITLE
docs: document orgs file format

### DIFF
--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -44,6 +44,19 @@ Use the generated data to feed into Snyk [Orgs API](https://snyk.docs.apiary.io/
 2. Run the command to create Orgs:
 `snyk-api-import orgs:create --file=group-<snyk_group_id>-github-<com|enterprise>-orgs.json`
 
+The file format required for this looks like so:
+```
+"orgs": [
+  {
+    "groupId": "<public_snyk_group_id>",
+    "name": "<name_of_the_organization>",
+    "sourceOrgId": "<public_snyk_organization_id>"
+  }
+]
+```
+- `groupId` - public id of the Snyk Group where the organization is to be created
+- `name` - name to use when creating the organization
+- `sourceOrgI` - **optional** public id of a Snyk organization to copy settings from
 
 ## Recommendations
 - have [notifications disabled](https://snyk.docs.apiary.io/#reference/organizations/notification-settings/set-notification-settings) for emails etc to avoid receiving import notifications


### PR DESCRIPTION
Orgs json format required for creating organizations

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Document required format for input json file for `orgs:create` command
