### PR TITLE
fix: use streams for org json loading

### DIFF
--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -14,6 +14,7 @@ import { getLoggingPath } from '../lib';
 import { logImportedBatch } from '../loggers/log-imported-batch';
 import { IMPORT_LOG_NAME } from '../common';
 import { generateTargetId } from '../generate-target-id';
+import { streamData } from '../stream-data';
 
 const debug = debugLib('snyk:import-projects-script');
 
@@ -118,7 +119,7 @@ export async function importProjects(
 
   let targets: ImportTarget[] = [];
   try {
-    targets = await parseTargetData(fileName);
+    targets = await streamData<ImportTarget>(fileName, 'targets');
   } catch (e) {
     throw new Error(`Failed to parse targets from ${fileName}:\n${e.message}`);
   }
@@ -179,31 +180,4 @@ export async function importProjects(
     projects.push(...res.projects);
   }
   return { projects, skippedTargets, filteredTargets, targets };
-}
-
-export async function parseTargetData(
-  logFile: string,
-): Promise<ImportTarget[]> {
-  return new Promise((resolve, reject) => {
-    let targets: ImportTarget[] = [];
-    fs.createReadStream(logFile)
-      .pipe(split())
-      .on('data', (lineObj) => {
-        if (!lineObj) {
-          return;
-        }
-        try {
-          targets = JSON.parse(lineObj).targets;
-        } catch (e) {
-          console.log(e);
-        }
-      })
-      .on('error', (err) => {
-        console.error('Failed to createReadStream for file: ' + err);
-        return reject(err);
-      })
-      .on('end', async () => {
-        return resolve(targets);
-      });
-  });
 }

--- a/src/stream-data.ts
+++ b/src/stream-data.ts
@@ -1,0 +1,75 @@
+import * as debugLib from 'debug';
+
+import * as fs from 'fs';
+import split = require('split');
+
+const debug = debugLib('streamData:load-file');
+
+export async function streamData<DataType>(
+  file: string,
+  jsonKey: string,
+): Promise<DataType[]> {
+  let res;
+  debug('Trying streamMinifiedJson');
+  res = await streamMinifiedJson<DataType>(file, jsonKey);
+  if (!res) {
+    debug(
+      `Failed to load as minified JSON, trying to load as beautified JSON with spaces`,
+    );
+    res = await streamBeautifiedJson<DataType>(file, jsonKey);
+  }
+  return res;
+}
+
+export async function streamMinifiedJson<DataType>(
+  file: string,
+  arrayKey: string,
+): Promise<DataType[]> {
+  return new Promise((resolve, reject) => {
+    let data: DataType[];
+    fs.createReadStream(file)
+      .pipe(split())
+      .on('data', (lineObj) => {
+        if (!lineObj) {
+          return;
+        }
+        try {
+          const json = JSON.parse(lineObj);
+          data = json[arrayKey];
+        } catch (e) {
+          debug('ERROR parsing line: ', e);
+        }
+      })
+      .on('error', (err) => {
+        debug('Failed to createReadStream for file: ' + err);
+        return reject(err);
+      })
+      .on('end', async () => resolve(data));
+  });
+}
+
+export async function streamBeautifiedJson<DataType>(
+  file: string,
+  arrayKey: string,
+): Promise<DataType[]> {
+  return new Promise((resolve, reject) => {
+    let data: DataType[];
+    fs.createReadStream(file)
+      .on('data', (jsonData) => {
+        if (!jsonData) {
+          return;
+        }
+        try {
+          const json = JSON.parse(jsonData);
+          data = json[arrayKey];
+        } catch (e) {
+          debug('ERROR parsing: ', e);
+        }
+      })
+      .on('error', (err) => {
+        debug('Failed to createReadStream for file: ' + err);
+        return reject(err);
+      })
+      .on('end', async () => resolve(data));
+  });
+}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Migrate to using streams for loading orgs file as well, support both minified and beautified format json