### PR TITLE
feat: incremental back off when an upstream rate limit error is seen from import

### DIFF
--- a/src/lib/source-handlers/github/list-repos.ts
+++ b/src/lib/source-handlers/github/list-repos.ts
@@ -70,8 +70,8 @@ async function fetchAllRepos(
     } catch (e) {
       debug(`Failed to fetch page: ${currentPage}`, e);
       if ([403, 500, 502].includes(e.status) && retries < MAX_RETRIES) {
+        const sleepTime = 120000 * retries; // 2 mins x retry attempt
         retries = retries + 1;
-        const sleepTime = 120000; // 2 mins
         console.error(`Sleeping for ${sleepTime} ms`);
         await new Promise((r) => setTimeout(r, sleepTime));
       } else {

--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -150,7 +150,10 @@ export async function importProjects(
   }
   const requestManager = new requestsManager({
     userAgentPrefix: 'snyk-api-import',
+    period: 1000,
+    maxRetryCount: 5
   });
+
   for (
     let targetIndex = 0;
     targetIndex < filteredTargets.length;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Sleep for longer periods with each retry if the upstream source control management system sent back `429` error (aka rate limit exceeded)
