### PR TITLE
feat: add GitLab functionality to import only new repos

### DIFF
--- a/src/cmds/list:imported.ts
+++ b/src/cmds/list:imported.ts
@@ -36,6 +36,7 @@ const entityName: {
   github: 'repo',
   'github-enterprise': 'repo',
   'bitbucket-cloud': 'repo',
+  'gitlab': 'repo',
   gcr: 'images',
   'docker-hub': 'images',
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -92,6 +92,7 @@ export enum SupportedIntegrationTypesToListSnykTargets {
   GITHUB = 'github',
   GHE = 'github-enterprise',
   BITBUCKET_CLOUD = 'bitbucket-cloud',
+  GITLAB = 'gitlab',
   GCR = 'gcr',
   DOCKER_HUB = 'docker-hub',
 }

--- a/src/scripts/generate-imported-targets-from-snyk.ts
+++ b/src/scripts/generate-imported-targets-from-snyk.ts
@@ -53,6 +53,7 @@ const targetGenerators = {
   [SupportedIntegrationTypesToListSnykTargets.GITHUB]: projectToTarget,
   [SupportedIntegrationTypesToListSnykTargets.GHE]: projectToTarget,
   [SupportedIntegrationTypesToListSnykTargets.BITBUCKET_CLOUD]: projectToTarget,
+  [SupportedIntegrationTypesToListSnykTargets.GITLAB]: projectToTarget,
   [SupportedIntegrationTypesToListSnykTargets.GCR]: imageProjectToTarget,
   [SupportedIntegrationTypesToListSnykTargets.DOCKER_HUB]: imageProjectToTarget,
 };


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

This adds functionality to only import newly added repos from GitLab into Snyk.
