### PR TITLE
feat: change "path" to "full_path" to support sub-groups

### DIFF
--- a/src/lib/source-handlers/gitlab/list-groups.ts
+++ b/src/lib/source-handlers/gitlab/list-groups.ts
@@ -28,7 +28,7 @@ async function fetchOrgsForPage(
 
     orgsData.push(
       ...orgs.map((org: any) => ({
-        name: org.path,
+        name: org.full_path,
         id: org.id,
         url: org.web_url,
       })),


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

GitLab has the concept of "sub-groups" and if they exist, currently our logic creates the sub-group as a Snyk org, but will then return a 404 when it tries to import the repos from GitLab. This is because Snyk is calling https://gitlab.com/bar instead of https://gitlab.com/foo/bar. This PR uses "full_path" instead of "path" which rectifies the issue.
