### PR TITLE
fix: improve error handling & messages when received 401

### DIFF
--- a/src/lib/get-import-path.ts
+++ b/src/lib/get-import-path.ts
@@ -32,6 +32,6 @@ export function getImportProjectsFile(filePath?: string): string {
   }
 
   throw new Error(
-    `Please set the SNYK_IMPORT_PATH e.g. export SNYK_IMPORT_PATH='~/my/path/to/import-projects.json'`,
+    `Could not find the import file, locations tried:${[process.env.SNYK_IMPORT_PATH, filePath, defaultFile].join(',')}. Please set the location via --file or SNYK_IMPORT_PATH e.g. export SNYK_IMPORT_PATH='~/my/path/to/import-projects.json'`,
   );
 }

--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -119,7 +119,7 @@ export async function importProjects(
 
   let targets: ImportTarget[] = [];
   try {
-    targets = await streamData<ImportTarget>(fileName, 'targets');
+    targets = await streamData<ImportTarget>(fileName, 'targets') ?? [];
   } catch (e) {
     throw new Error(`Failed to parse targets from ${fileName}:\n${e.message}`);
   }

--- a/src/stream-data.ts
+++ b/src/stream-data.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import split = require('split');
 
 const debug = debugLib('streamData:load-file');
+const debugSnyk = debugLib('snyk:load-file');
 
 export async function streamData<DataType>(
   file: string,
@@ -37,7 +38,8 @@ export async function streamMinifiedJson<DataType>(
           const json = JSON.parse(lineObj);
           data = json[arrayKey];
         } catch (e) {
-          debug('ERROR parsing line: ', e);
+          debugSnyk(`ERROR: Could not find "${arrayKey}" key in json. Make sure the JSON is valid and the key is present`)
+          debug(e.message);
         }
       })
       .on('error', (err) => {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Some of the errors for 401 & missing required target json keys were coming back to the user uncaught/sanitized. Adding a fix for this

### Screenshots
Before we would show a type error, now we show the correct error bubbled up for bad auth:
<img width="858" alt="CleanShot 2021-12-02 at 14 12 41@2x" src="https://user-images.githubusercontent.com/2911613/144438779-df273812-6901-4efa-ad7e-29821567d515.png">


Before
<img width="855" alt="CleanShot 2021-12-02 at 14 14 50@2x" src="https://user-images.githubusercontent.com/2911613/144438929-039c34b6-e8f6-4026-b6b1-b16376cb5959.png">
Now
<img width="857" alt="CleanShot 2021-12-02 at 14 15 26@2x" src="https://user-images.githubusercontent.com/2911613/144439001-0dede1e5-15fb-4364-9b90-ab14dc454a06.png">

