### PR TITLE
fix: check for correct status code prop name  before failing import

### DIFF
--- a/src/lib/api/group/index.ts
+++ b/src/lib/api/group/index.ts
@@ -42,9 +42,11 @@ export async function createOrg(
     url: `/group/${groupId}/org`,
     body: JSON.stringify(body),
   });
-  if (res.statusCode && res.statusCode !== 200) {
+  const statusCode = res.statusCode || res.status;
+  if (!statusCode || statusCode !== 200) {
     throw new Error(
-      'Expected a 200 response, instead received: ' + JSON.stringify(res),
+      'Expected a 200 response, instead received: ' +
+        JSON.stringify({ data: res.data, status: statusCode }),
     );
   }
   return res.data;
@@ -75,7 +77,8 @@ export async function listOrgs(
     url: `/group/${groupId}/orgs?query=${query}`,
     body: JSON.stringify({}),
   });
-  if (res.statusCode && res.statusCode !== 200) {
+  const statusCode = res.statusCode || res.status;
+  if (statusCode || statusCode !== 200) {
     throw new Error(
       'Expected a 200 response, instead received: ' + JSON.stringify(res),
     );

--- a/src/lib/api/import/index.ts
+++ b/src/lib/api/import/index.ts
@@ -54,10 +54,10 @@ export async function importTarget(
       'post',
       body,
     );
-    if (!res.statuscode || res.statusCode !== 201) {
+    if (!res.statusCode || res.statusCode !== 201) {
       throw new Error(
         'Expected a 201 response, instead received: ' +
-          JSON.stringify(res.data),
+          JSON.stringify({ data: res.data, statusCode: res.statusCode}),
       );
     }
     const locationUrl = res.headers?.['location'];

--- a/src/lib/api/import/index.ts
+++ b/src/lib/api/import/index.ts
@@ -54,7 +54,8 @@ export async function importTarget(
       'post',
       body,
     );
-    if (!res.statusCode || res.statusCode !== 201) {
+    const statusCode = res.statusCode || res.status;
+    if (!statusCode || statusCode !== 201) {
       throw new Error(
         'Expected a 201 response, instead received: ' +
           JSON.stringify({ data: res.data, statusCode: res.statusCode}),

--- a/src/lib/api/org/index.ts
+++ b/src/lib/api/org/index.ts
@@ -32,10 +32,11 @@ export async function listIntegrations(
     body: JSON.stringify({}),
   });
 
-  if (res.statusCode && res.statusCode !== 201) {
+  const statusCode = res.statusCode || res.status;
+  if (!statusCode || statusCode !== 201) {
     throw new Error(
       'Expected a 201 response, instead received: ' +
-        JSON.stringify(res.data || res.body),
+        JSON.stringify({ data: res.data || res.body, status: statusCode }),
     );
   }
   return res.data || {};
@@ -89,10 +90,11 @@ export async function setNotificationPreferences(
       body: JSON.stringify(settings),
     });
 
-    if (res.statusCode && res.statusCode !== 201) {
+    const statusCode = res.statusCode || res.status;
+    if (!statusCode || statusCode !== 201) {
       throw new Error(
         'Expected a 201 response, instead received: ' +
-          JSON.stringify(res.data || res.data),
+          JSON.stringify({ data: res.data, status: statusCode }),
       );
     }
     return res.data || {};
@@ -121,10 +123,11 @@ export async function deleteOrg(
     url: `/org/${orgId}`,
     body: JSON.stringify({}),
   });
-
-  if (res.statusCode && res.statusCode !== 204) {
+  const statusCode = res.statusCode || res.status;
+  if (!statusCode || statusCode !== 204) {
     throw new Error(
-      'Expected a 204 response, instead received: ' + JSON.stringify(res.data),
+      'Expected a 204 response, instead received: ' +
+        JSON.stringify({ data: res.data, status: statusCode }),
     );
   }
   return res.data;
@@ -161,10 +164,11 @@ export async function listProjects(
       body: JSON.stringify(filters),
     });
 
-    if (res.statusCode && res.statusCode !== 201) {
+    const statusCode = res.statusCode || res.status;
+    if (!statusCode || statusCode !== 201) {
       throw new Error(
         'Expected a 201 response, instead received: ' +
-          JSON.stringify(res.data || res.data),
+          JSON.stringify({ data: res.data, status: statusCode }),
       );
     }
     return res.data || {};

--- a/src/lib/api/poll-import/index.ts
+++ b/src/lib/api/poll-import/index.ts
@@ -41,10 +41,11 @@ export async function pollImportUrl(
       body: JSON.stringify({}),
     });
     const importStatus: PollImportResponse = res.data;
-    if (res.statusCode && res.statusCode !== 200) {
+    const statusCode = res.statusCode || res.status;
+    if (!statusCode || statusCode !== 200) {
       throw new Error(
         'Expected a 200 response, instead received: ' +
-          JSON.stringify(res.data),
+          JSON.stringify({ data: res.data, status: statusCode }),
       );
     }
     debug(`Import task status is "${importStatus.status}"`);

--- a/src/lib/api/project/index.ts
+++ b/src/lib/api/project/index.ts
@@ -36,7 +36,8 @@ export async function deleteProjects(
         },
       },
     );
-    if (res.statusCode !== 200) {
+    const statusCode = res.statusCode;
+    if (!statusCode || statusCode !== 200) {
       throw new Error(
         `Expected a 200 response, instead received statusCode: ${
           res.statusCode

--- a/src/scripts/import-projects.ts
+++ b/src/scripts/import-projects.ts
@@ -153,7 +153,7 @@ export async function importProjects(
   const requestManager = new requestsManager({
     userAgentPrefix: 'snyk-api-import',
     period: 1000,
-    maxRetryCount: 5,
+    maxRetryCount: 3,
   });
 
   for (


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Fix [a bug](https://github.com/snyk-tech-services/snyk-api-import/pull/243/files#diff-c24486035bedf2797b3c0daba7cad3100f8504453a264262789a0131085f4411R57) that is treating successful imports as fails & add more logging. Reduce retry count as we retry also based on the error code in the backend and in the tool
