### PR TITLE
fix SNYK_IMPORT_PATH var usage

### DIFF
--- a/src/cmds/import.ts
+++ b/src/cmds/import.ts
@@ -12,7 +12,7 @@ export const desc = 'Kick off API powered import';
 export const builder = {
   file: {
     required: false,
-    default: 'import-projects.json',
+    default: false,
     desc: 'Path to json file that contains the targets to be imported',
   },
 };


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

according to the [docs](https://github.com/snyk-tech-services/snyk-api-import/blob/e1cbfdd8eafc31ad72adb21f2e72cabb6c79a785/docs/import.md#2-set-the-env-vars), `SNYK_IMPORT_PATH` can be used instead of command line `--file` option. it doesn't work due to [this](https://github.com/snyk-tech-services/snyk-api-import/blob/master/src/lib/get-import-path.ts#L5) logic and default value set [here](https://github.com/snyk-tech-services/snyk-api-import/blob/e1cbfdd8eafc31ad72adb21f2e72cabb6c79a785/src/cmds/import.ts#L15).

this PR removes default, so when `--file` is not set, ENV var is being used.

### Notes for the reviewer

n/a

### More information

n/a

### Screenshots

n/a
