### PR TITLE
fix: respect the SNYK_IMPORT_PATH variable when set

### DIFF
--- a/src/cmds/import.ts
+++ b/src/cmds/import.ts
@@ -12,7 +12,7 @@ export const desc = 'Kick off API powered import';
 export const builder = {
   file: {
     required: false,
-    default: 'import-projects.json',
+    default: undefined,
     desc: 'Path to json file that contains the targets to be imported',
   },
 };


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Respect the SNYK_IMPORT_PATH variable when set, at the moment `--file` overrides it always.

