### PR TITLE
fix: increase sleep duration when rate limiting error seen

### DIFF
--- a/src/lib/api/import/index.ts
+++ b/src/lib/api/import/index.ts
@@ -143,7 +143,7 @@ async function requestWithRateLimitHandling(
       attempt += 1;
       debug('Failed:' + JSON.stringify(e));
       if (e.data.code === 429) {
-        const sleepTime = 120000 * attempt; // 2 mins x attempt
+        const sleepTime = 600000 * attempt; // 10 mins x attempt with a max of ~ 1hr
         console.error(
           `Received a rate limit error, sleeping for ${sleepTime} ms (attempt # ${attempt})`,
         );


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Bump the rate limited triggered sleep to make it cover a max of ~1hr
