### PR TITLE
fix: expect 200 on GET projects

### DIFF
--- a/src/lib/api/org/index.ts
+++ b/src/lib/api/org/index.ts
@@ -165,9 +165,9 @@ export async function listProjects(
     });
 
     const statusCode = res.statusCode || res.status;
-    if (!statusCode || statusCode !== 201) {
+    if (!statusCode || statusCode !== 200) {
       throw new Error(
-        'Expected a 201 response, instead received: ' +
+        'Expected a 200 response, instead received: ' +
           JSON.stringify({ data: res.data, status: statusCode }),
       );
     }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
GET projects is expected to return a `200` not `201`