### PR TITLE
feat: orgs data command for bitbucket server

### DIFF
--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -4,6 +4,7 @@
 - Generating the data to create Organizations in Snyk
   - [Github](#githubcom--github-enterprise)
   - [Gitlab](#gitlabcom--hosted-gitlab)
+  - [Bitbucket-Server](#bitbucket-server)
 - [Creating the organizations](#creating-organizations-in-snyk-1)
   - [via the API](#via-api)
   - [via the `orgs:create` util](#via-orgscreate-util)
@@ -14,8 +15,8 @@ Before an import can begin Snyk needs to be setup with the Organizations you wil
 It is recommended to have as many Organizations in Snyk as you have in the source you are importing from. So for Github this would mean mirroring the Github organizations in Snyk. The tool provides a utility that can be used to make this simpler when using Groups & Organizations in Snyk.
 
 # Generating the data required to create Organizations in Snyk with `orgs:data` util
-This util helps generate data needed to mirror the Github.com / Github Enterprise organization structure in Snyk.
-This is an opinionated util and will assume every organization in Github.com / Github Enterprise should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
+This util helps generate data needed to mirror the Github.com / Github Enterprise / Gitlab / Bitbucket Server organization structure in Snyk.
+This is an opinionated util and will assume every organization in Github.com / Github Enterprise / Gitlab / Bitbucket Server should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
 
 ## Github.com / Github Enterprise
 1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
@@ -33,6 +34,14 @@ This will create the organization data in a file `group-<snyk_group_id>-github-<
  - **Hosted Gitlab:** `snyk-api-import orgs:data --source=gitlab --groupId=<snyk_group_id> -- sourceUrl=https://gitlab.custom.com`
 
 This will create the organization data in a file `group-<snyk_group_id>-gitlab-orgs.json`
+
+
+## Bitbucket Server
+1. set the [Bitbucket Server access token](https://www.jetbrains.com/help/youtrack/standalone/integration-with-bitbucket-server.html#enable-youtrack-integration-bbserver) as an environment variable: `export BITBUCKET_SERVER_TOKEN=your_personal_access_token`
+2. Run the command to generate organization data:
+ - `snyk-api-import orgs:data --source=bitbucket-server --groupId=<snyk_group_id> -- sourceUrl=https://bitbucket-server.custom.com`
+
+This will create the organization data in a file `group-<snyk_group_id>-bitbucket-server-orgs.json`
 
 # Creating Organizations in Snyk
 Use the generated data file to help create the organizations via API or use the provided util.

--- a/src/lib/source-handlers/bitbucket-server/get-bitbucket-server-token.ts
+++ b/src/lib/source-handlers/bitbucket-server/get-bitbucket-server-token.ts
@@ -1,0 +1,9 @@
+export function getBitbucketServerToken(): string {
+  const bitbucketServerToken = process.env.BITBUCKET_SERVER_TOKEN;
+  if (!bitbucketServerToken) {
+    throw new Error(
+      `Please set the BITBUCKET_SERVER_TOKEN e.g. export BITBUCKET_SERVER_TOKEN='mypersonalaccesstoken123'`,
+    );
+  }
+  return bitbucketServerToken;
+}

--- a/src/lib/source-handlers/bitbucket-server/index.ts
+++ b/src/lib/source-handlers/bitbucket-server/index.ts
@@ -1,0 +1,4 @@
+export * from './list-projects';
+export * from './list-repos';
+export * from './project-is-empty';
+export * from './types';

--- a/src/lib/source-handlers/bitbucket-server/list-projects.ts
+++ b/src/lib/source-handlers/bitbucket-server/list-projects.ts
@@ -1,0 +1,87 @@
+import * as needle from 'needle';
+import * as debugLib from 'debug';
+import Bottleneck from 'bottleneck';
+import { BitbucketServerProjectData } from './types';
+import { getBitbucketServerToken } from './get-bitbucket-server-token';
+
+const debug = debugLib('snyk:bitbucket-server');
+
+const limiter = new Bottleneck({
+  reservoir: 1000, // initial value
+  reservoirRefreshAmount: 1000,
+  reservoirRefreshInterval: 3600 * 1000,
+  maxConcurrent: 1,
+  minTime: 1000,
+});
+
+limiter.on('failed', async (error, jobInfo) => {
+  const id = jobInfo.options.id;
+  debug(`Job ${id} failed: ${error}`);
+  if (jobInfo.retryCount === 0) {
+    // Here we only retry once
+    debug(`Retrying job ${id} in 25ms!`);
+    return 25;
+  }
+});
+
+export async function fetchAllProjects(
+  url: string,
+  token: string,
+): Promise<unknown[]> {
+  let isLastPage = false;
+  let projects: unknown[] = [];
+  let pageCount = 1;
+  let start = 0;
+  const limit = 100;
+  while (!isLastPage) {
+    debug(`Fetching page ${pageCount} for projects\n`);
+    const { statusCode, body } = await limiter.schedule(() =>
+      needle(
+        'get',
+        `${url}/rest/api/1.0/projects?start=${start}&limit=${limit}`,
+        {
+          headers: { Authorization: 'Bearer ' + token },
+        },
+      ),
+    );
+    if (statusCode != 200) {
+      if (statusCode == 429) {
+        debug(
+          `Failed to fetch page: ${url}\n, Response Status: ${body}\nToo many requests \nWaiting for 3 minutes before resuming`,
+        );
+        await sleepNow(180000);
+        isLastPage = false;
+      } else {
+        debug(
+          `Failed to fetch page: ${url}\n, Response Status: ${statusCode}\nResponse Status Text: ${body} `,
+        );
+      }
+    }
+    const apiResponse = body['values'];
+    projects = projects.concat(apiResponse);
+    isLastPage = body['isLastPage'];
+    start = body['nextPageStart'] ? body['nextPageStart'] : -1;
+    pageCount++;
+  }
+  return projects;
+}
+
+const sleepNow = (delay: number): unknown =>
+  new Promise((resolve) => setTimeout(resolve, delay));
+
+export async function listBitbucketServerProjects(
+  sourceUrl?: string,
+): Promise<BitbucketServerProjectData[]> {
+  const bitbucketServerToken = getBitbucketServerToken();
+  if (!sourceUrl) {
+    throw new Error(
+      'Please provide required `sourceUrl` for Bitbucket Server source',
+    );
+  }
+  debug(`Fetching all projects data`);
+  const projects = (await fetchAllProjects(
+    sourceUrl,
+    bitbucketServerToken,
+  )) as BitbucketServerProjectData[];
+  return projects;
+}

--- a/src/lib/source-handlers/bitbucket-server/list-repos.ts
+++ b/src/lib/source-handlers/bitbucket-server/list-repos.ts
@@ -1,0 +1,70 @@
+import * as needle from 'needle';
+import * as debugLib from 'debug';
+import Bottleneck from 'bottleneck';
+import { BitbucketServerRepoData } from './types';
+
+const debug = debugLib('snyk:bitbucket-server');
+
+const limiter = new Bottleneck({
+  reservoir: 1000, // initial value
+  reservoirRefreshAmount: 1000,
+  reservoirRefreshInterval: 3600 * 1000,
+  maxConcurrent: 1,
+  minTime: 1000,
+});
+
+limiter.on('failed', async (error, jobInfo) => {
+  const id = jobInfo.options.id;
+  console.warn(`Job ${id} failed: ${error}`);
+  if (jobInfo.retryCount === 0) {
+    // Here we only retry once
+    console.log(`Retrying job ${id} in 25ms!`);
+    return 25;
+  }
+});
+
+export const fetchAllRepos = async (
+  url: string,
+  projectKey: string,
+  token: string,
+): Promise<BitbucketServerRepoData[]> => {
+  let isLastPage = false;
+  let values: BitbucketServerRepoData[] = [];
+  let pageCount = 1;
+  let start = 0;
+  const limit = 100;
+  while (!isLastPage) {
+    debug(`Fetching page ${pageCount} for ${projectKey}\n`);
+    const response = await limiter.schedule(() =>
+      needle(
+        'get',
+        `${url}/rest/api/1.0/projects/${projectKey}/repos/?start=${start}&limit=${limit}`,
+        {
+          headers: { Authorization: 'Bearer ' + token },
+        },
+      ),
+    );
+    if (response.statusCode != 200) {
+      if (response.statusCode == 429) {
+        debug(
+          `Failed to fetch page: ${url}\n, Response Status: ${response.body}\nToo many requests \nWaiting for 3 minutes before resuming`,
+        );
+        await sleepNow(180000);
+        isLastPage = false;
+      } else {
+        debug(
+          `Failed to fetch page: ${url}\n, Response Status: ${response.statusCode}\nResponse Status Text: ${response.body} `,
+        );
+      }
+    }
+    const apiResponse = response.body['values'];
+    values = values.concat(apiResponse);
+    isLastPage = response.body['isLastPage'];
+    start = response.body['nextPageStart'] || -1;
+    pageCount++;
+  }
+  return values;
+};
+
+const sleepNow = (delay: number): unknown =>
+  new Promise((resolve) => setTimeout(resolve, delay));

--- a/src/lib/source-handlers/bitbucket-server/project-is-empty.ts
+++ b/src/lib/source-handlers/bitbucket-server/project-is-empty.ts
@@ -1,0 +1,20 @@
+import { getBitbucketServerToken } from './get-bitbucket-server-token';
+import { fetchAllRepos } from './list-repos';
+
+export async function bitbucketServerProjectIsEmpty(
+  projectKey: string,
+  sourceUrl?: string,
+): Promise<boolean> {
+  const bitbucketServerToken = getBitbucketServerToken();
+  if (!sourceUrl) {
+    throw new Error(
+      'Please provide required `sourceUrl` for Bitbucket Server source',
+    );
+  }
+  const repos = await fetchAllRepos(
+    sourceUrl,
+    projectKey,
+    bitbucketServerToken,
+  );
+  return !repos || repos.length === 0;
+}

--- a/src/lib/source-handlers/bitbucket-server/types.ts
+++ b/src/lib/source-handlers/bitbucket-server/types.ts
@@ -1,0 +1,23 @@
+export interface repoListApiResponse {
+  size: number;
+  limit: number;
+  isLastPage: boolean;
+  start: number;
+  nextPageStart?: number;
+  values: unknown[];
+}
+
+export interface BitbucketServerRepoData {
+  name: string;
+  project: {
+    key: string;
+    name?: string;
+  };
+  public: boolean;
+}
+
+export interface BitbucketServerProjectData {
+  key: string;
+  id: string;
+  name: string;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,6 +85,7 @@ export enum SupportedIntegrationTypesImportOrgData {
   GITHUB = 'github',
   GHE = 'github-enterprise',
   GITLAB = 'gitlab',
+  BITBUCKET_SERVER = 'bitbucket-server',
 }
 
 // used to generate imported targets that exist in Snyk

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -10,6 +10,10 @@ import {
   gitlabGroupIsEmpty,
 } from '../lib/source-handlers/gitlab';
 import {
+  bitbucketServerProjectIsEmpty,
+  listBitbucketServerProjects,
+} from '../lib/source-handlers/bitbucket-server/';
+import {
   CreateOrgData,
   SupportedIntegrationTypesImportOrgData,
 } from '../lib/types';
@@ -19,12 +23,14 @@ const sourceGenerators = {
   [SupportedIntegrationTypesImportOrgData.GITLAB]: listGitlabGroups,
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizations,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubEnterpriseOrganizations,
+  [SupportedIntegrationTypesImportOrgData.BITBUCKET_SERVER]: listBitbucketServerProjects,
 };
 
 const sourceNotEmpty = {
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizationIsEmpty,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubOrganizationIsEmpty,
   [SupportedIntegrationTypesImportOrgData.GITLAB]: gitlabGroupIsEmpty,
+  [SupportedIntegrationTypesImportOrgData.BITBUCKET_SERVER]: bitbucketServerProjectIsEmpty,
 };
 
 export const entityName: {
@@ -33,6 +39,7 @@ export const entityName: {
   github: 'organization',
   'github-enterprise': 'organization',
   gitlab: 'group',
+  'bitbucket-server': 'project',
 };
 
 const exportFileName: {
@@ -41,6 +48,7 @@ const exportFileName: {
   github: 'github-com',
   'github-enterprise': 'github-enterprise',
   gitlab: 'gitlab',
+  'bitbucket-server': 'bitbucket-server',
 };
 
 export async function generateOrgImportDataFile(

--- a/test/lib/source-handlers/bitbucket-server/bitbucket-server.test.ts
+++ b/test/lib/source-handlers/bitbucket-server/bitbucket-server.test.ts
@@ -1,0 +1,15 @@
+import { listBitbucketServerProjects } from '../../../../src/lib/source-handlers/bitbucket-server/list-projects';
+
+jest.setTimeout(60000);
+
+describe('listBitbucketServerProjects script', () => {
+  it('list projects', async () => {
+    process.env.BITBUCKET_SERVER_TOKEN = process.env.BBS_TOKEN;
+    const sourceUrl = process.env.BBS_SOURCE_URL;
+    const projects = await listBitbucketServerProjects(sourceUrl);
+    expect(projects).toBeTruthy();
+    expect(projects[0]).toHaveProperty('key', expect.any(String));
+    expect(projects[0]).toHaveProperty('id', expect.any(Number));
+    expect(projects[0]).toHaveProperty('name', expect.any(String));
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Adds the orgs:data command support for Bitbucket Server

### More information

- [Jira Ticket](https://snyksec.atlassian.net/browse/TECHSERV-1660)
