### PR TITLE
feat: `import:data` and `org:data` commands for bitbucket server

### DIFF
--- a/docs/import-data.md
+++ b/docs/import-data.md
@@ -7,6 +7,7 @@ This is a util that can help generate the import json data needed by the import 
   - [Github](#githubcom--github-enterprise)
   - [Gitlab](#gitlabcom--hosted-gitlab)
   - [Azure-Repos](#devazurecom--hosted-azure)
+  - [Bitbucket-Server](#bitbucket-server)
 - [Recommendations](#recommendations)
 
 
@@ -96,6 +97,35 @@ This is a util that can help generate the import json data needed by the import 
 3. Run the command to generate import data:
  - **dev.azure.com:** `DEBUG=snyk* AZURE_TOKEN=*** SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=azure-repos --integrationType=azure-repos`
  - **Hosted Azure:** `DEBUG=snyk* AZURE_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=azure-repos --integrationType=azure-repos --sourceUrl=https://azure.custom.com`
+
+4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
+
+
+## Bitbucket Server
+*Please note that this tool uses Bitbucket server API version 1.0*
+1. Set the [Bitbucket Server personal access token](https://www.jetbrains.com/help/youtrack/standalone/integration-with-bitbucket-server.html#enable-youtrack-integration-bbserver) as an environment variable: `export BITBUCKET_SERVER_TOKEN=your_personal_access_token`
+2. You will need to have the organizations data in json as an input to this command to help map Snyk organization IDs and Integration Ids that must be used during import against individual targets to be imported. The following format is required:
+  ```
+  {
+    "orgData": [
+      {
+        "name": "<project_name_in_bitbucket_server_used_to_list_repos>",
+        "orgId": "<snyk_org_id>",
+        "integrations": {
+          "bitbucket-server": "<snyk_org_integration_id>",
+        },
+      },
+      {...}
+    ]
+  }
+  ```
+  Note: the "name" of the Bitbucket server project is required in order to list all repos belonging to that Project via Bibucket server API, the Snyk specific data accompanying that Project name will be used as the information to generate import data assuming all repos in that Project will be imported into a given Snyk organization. This is opinionated! If you want to customize this please manually craft the import data described in [import.md](/docs/import.md)
+  - Bitbucket Server Projects can be listed using the [/projects API](https://docs.atlassian.com/bitbucket-server/rest/7.19.2/bitbucket-rest.html#:~:text=409%20%2D%20application/json%20(errors)%20%5Bexpand%5D-,GET,-/rest/api/1.0/projects%3Fname)
+  - Integrations can be listed via [Snyk Integrations API](https://snyk.docs.apiary.io/#reference/integrations/integrations/list)
+  - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
+
+3. Run the command to generate import data:
+ - **Bitbucket Server:** `DEBUG=snyk* BITBUCKET_SERVER_TOKEN=*** SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=bitbucket-server --integrationType=bitbucket-server --sourceUrl=https://bitbucket-server.dev.example.com`
 
 4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
 

--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -4,6 +4,7 @@
 - Generating the data to create Organizations in Snyk
   - [Github](#githubcom--github-enterprise)
   - [Gitlab](#gitlabcom--hosted-gitlab)
+  - [Bitbucket-Server](#bitbucket-server)
 - [Creating the organizations](#creating-organizations-in-snyk-1)
   - [via the API](#via-api)
   - [via the `orgs:create` util](#via-orgscreate-util)
@@ -14,8 +15,8 @@ Before an import can begin Snyk needs to be setup with the Organizations you wil
 It is recommended to have as many Organizations in Snyk as you have in the source you are importing from. So for Github this would mean mirroring the Github organizations in Snyk. The tool provides a utility that can be used to make this simpler when using Groups & Organizations in Snyk.
 
 # Generating the data required to create Organizations in Snyk with `orgs:data` util
-This util helps generate data needed to mirror the Github.com / Github Enterprise organization structure in Snyk.
-This is an opinionated util and will assume every organization in Github.com / Github Enterprise should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
+This util helps generate data needed to mirror the Github.com / Github Enterprise / Gitlab / Bitbucket Server organization structure in Snyk.
+This is an opinionated util and will assume every organization in Github.com / Github Enterprise / Gitlab / Bitbucket Server should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
 
 ## Github.com / Github Enterprise
 1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
@@ -34,6 +35,14 @@ This will create the organization data in a file `group-<snyk_group_id>-github-<
 
 This will create the organization data in a file `group-<snyk_group_id>-gitlab-orgs.json`
 
+
+## Bitbucket Server
+1. set the [Bitbucket Server access token](https://www.jetbrains.com/help/youtrack/standalone/integration-with-bitbucket-server.html#enable-youtrack-integration-bbserver) as an environment variable: `export BITBUCKET_SERVER_TOKEN=your_personal_access_token`
+2. Run the command to generate organization data:
+ - `snyk-api-import orgs:data --source=bitbucket-server --groupId=<snyk_group_id> -- sourceUrl=https://bitbucket-server.custom.com`
+
+This will create the organization data in a file `group-<snyk_group_id>-bitbucket-server-orgs.json`
+
 # Creating Organizations in Snyk
 Use the generated data file to help create the organizations via API or use the provided util.
 ## via API
@@ -42,7 +51,11 @@ Use the generated data to feed into Snyk [Orgs API](https://snyk.docs.apiary.io/
 ## via `orgs:create` util
 1. set the `SNYK_TOKEN` environment variable - your [Snyk api token](https://app.snyk.io/account)
 2. Run the command to create Orgs:
-`snyk-api-import orgs:create --file=group-<snyk_group_id>-github-<com|enterprise>-orgs.json`
+`snyk-api-import orgs:create --noDuplicateNames --includeExistingOrgsInOutput --file=group-<snyk_group_id>-github-<com|enterprise>-orgs.json`
+
+- Using the `noDuplicateNames` flag (optional) will Skip creating an organization if the given name is already taken within the Group.
+- Using the `includeExistingOrgsInOutput` flag (optional, default is "true") will Log existing organization information as well as newly created. To set this flag as false, please use "--no-includeExistingOrgsInOutput" in the command, like so:
+`snyk-api-import orgs:create --no-includeExistingOrgsInOutput --file=group-<snyk_group_id>-github-<com|enterprise>-orgs.json`
 
 The file format required for this looks like so:
 ```

--- a/src/cmds/import:data.ts
+++ b/src/cmds/import:data.ts
@@ -13,7 +13,8 @@ export const builder = {
   orgsData: {
     required: true,
     default: undefined,
-    desc: 'Path to organizations data file generated with "orgs:data" command',
+    desc:
+      'Path to organizations data file generated with "orgs:create" command',
   },
   source: {
     required: true,
@@ -44,6 +45,7 @@ const entityName: {
   'github-enterprise': 'org',
   gitlab: 'group',
   'azure-repos': 'org',
+  'bitbucket-server': 'project',
 };
 
 export async function handler(argv: {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,3 +14,4 @@ export * from './filter-out-existing-orgs';
 export * from './source-handlers/github';
 export * from './source-handlers/gitlab';
 export * from './source-handlers/azure';
+export * from './source-handlers/bitbucket-server';

--- a/src/lib/source-handlers/bitbucket-server/get-bitbucket-server-token.ts
+++ b/src/lib/source-handlers/bitbucket-server/get-bitbucket-server-token.ts
@@ -1,0 +1,9 @@
+export function getBitbucketServerToken(): string {
+  const bitbucketServerToken = process.env.BITBUCKET_SERVER_TOKEN;
+  if (!bitbucketServerToken) {
+    throw new Error(
+      `Please set the BITBUCKET_SERVER_TOKEN e.g. export BITBUCKET_SERVER_TOKEN='mypersonalaccesstoken123'`,
+    );
+  }
+  return bitbucketServerToken;
+}

--- a/src/lib/source-handlers/bitbucket-server/index.ts
+++ b/src/lib/source-handlers/bitbucket-server/index.ts
@@ -1,0 +1,4 @@
+export * from './list-projects';
+export * from './list-repos';
+export * from './project-is-empty';
+export * from './types';

--- a/src/lib/source-handlers/bitbucket-server/list-projects.ts
+++ b/src/lib/source-handlers/bitbucket-server/list-projects.ts
@@ -1,0 +1,116 @@
+import * as needle from 'needle';
+import * as debugLib from 'debug';
+import Bottleneck from 'bottleneck';
+import { BitbucketServerProjectData } from './types';
+import { getBitbucketServerToken } from './get-bitbucket-server-token';
+
+const debug = debugLib('snyk:bitbucket-server');
+
+const limiter = new Bottleneck({
+  reservoir: 1000, // initial value
+  reservoirRefreshAmount: 1000,
+  reservoirRefreshInterval: 3600 * 1000,
+  maxConcurrent: 1,
+  minTime: 1000,
+});
+
+limiter.on('failed', async (error, jobInfo) => {
+  const id = jobInfo.options.id;
+  debug(`Job ${id} failed: ${error}`);
+  if (jobInfo.retryCount === 0) {
+    // Here we only retry once
+    debug(`Retrying job ${id} in 25ms!`);
+    return 25;
+  }
+});
+
+const fetchAllProjects = async (
+  url: string,
+  token: string,
+): Promise<BitbucketServerProjectData[]> => {
+  let lastPage = false;
+  let projectsList: BitbucketServerProjectData[] = [];
+  let pageCount = 1;
+  let startFrom = 0;
+  const limit = 100;
+  while (!lastPage) {
+    debug(`Fetching page ${pageCount} for projects\n`);
+    try {
+      const { projects, isLastPage, start } = await getProjects(
+        url,
+        token,
+        startFrom,
+        limit,
+      );
+      lastPage = isLastPage;
+      startFrom = start;
+      projectsList = projectsList.concat(projects);
+      pageCount++;
+    } catch (err) {
+      throw new Error(JSON.stringify(err));
+    }
+  }
+  return projectsList;
+};
+
+const getProjects = async (
+  url: string,
+  token: string,
+  startFrom: number,
+  limit: number,
+): Promise<{
+  projects: BitbucketServerProjectData[];
+  isLastPage: boolean;
+  start: number;
+}> => {
+  let isLastPage = false;
+  let start = 0;
+  let projects: BitbucketServerProjectData[] = [];
+  const { body, statusCode } = await limiter.schedule(() =>
+    needle(
+      'get',
+      `${url}/rest/api/1.0/projects?start=${startFrom}&limit=${limit}`,
+      {
+        headers: { Authorization: 'Bearer ' + token },
+      },
+    ),
+  );
+  if (statusCode != 200) {
+    if (statusCode == 429) {
+      debug(
+        `Failed to fetch page: ${url}/rest/api/1.0/projects?start=${startFrom}&limit=${limit}\n, Response Status: ${JSON.stringify(
+          body,
+        )}\nToo many requests \nWaiting for 3 minutes before resuming`,
+      );
+      await sleepNow(180000);
+      isLastPage = false;
+    } else {
+      throw new Error(
+        `Failed to fetch page: ${url}/rest/api/1.0/projects?start=${startFrom}&limit=${limit}\n, Response Status: ${statusCode}\nResponse Status Text: ${JSON.stringify(
+          body,
+        )} `,
+      );
+    }
+  }
+  projects = body['values'];
+  isLastPage = body['isLastPage'];
+  start = body['nextPageStart'] || -1;
+  return { projects, isLastPage, start };
+};
+
+const sleepNow = (delay: number): unknown =>
+  new Promise((resolve) => setTimeout(resolve, delay));
+
+export async function listBitbucketServerProjects(
+  sourceUrl?: string,
+): Promise<BitbucketServerProjectData[]> {
+  const bitbucketServerToken = getBitbucketServerToken();
+  if (!sourceUrl) {
+    throw new Error(
+      'Please provide required `sourceUrl` for Bitbucket Server source',
+    );
+  }
+  debug(`Fetching all projects data`);
+  const projects = await fetchAllProjects(sourceUrl, bitbucketServerToken);
+  return projects;
+}

--- a/src/lib/source-handlers/bitbucket-server/list-repos.ts
+++ b/src/lib/source-handlers/bitbucket-server/list-repos.ts
@@ -1,0 +1,123 @@
+import * as needle from 'needle';
+import * as debugLib from 'debug';
+import Bottleneck from 'bottleneck';
+import { BitbucketServerRepoData } from './types';
+import { getBitbucketServerToken } from './get-bitbucket-server-token';
+
+const debug = debugLib('snyk:bitbucket-server');
+
+const limiter = new Bottleneck({
+  reservoir: 1000, // initial value
+  reservoirRefreshAmount: 1000,
+  reservoirRefreshInterval: 3600 * 1000,
+  maxConcurrent: 1,
+  minTime: 1000,
+});
+
+limiter.on('failed', async (error, jobInfo) => {
+  const id = jobInfo.options.id;
+  debug(`Job ${id} failed: ${error}`);
+  if (jobInfo.retryCount === 0) {
+    // Here we only retry once
+    console.log(`Retrying job ${id} in 25ms!`);
+    return 25;
+  }
+});
+
+export const fetchAllRepos = async (
+  url: string,
+  projectKey: string,
+  token: string,
+): Promise<BitbucketServerRepoData[]> => {
+  let lastPage = false;
+  let repoList: BitbucketServerRepoData[] = [];
+  let pageCount = 1;
+  let startFrom = 0;
+  const limit = 100;
+  while (!lastPage) {
+    debug(`Fetching page ${pageCount} for ${projectKey}\n`);
+    try {
+      const { repos, isLastPage, start } = await getRepos(
+        url,
+        projectKey,
+        token,
+        startFrom,
+        limit,
+      );
+      repoList = repoList.concat(repos);
+      lastPage = isLastPage;
+      startFrom = start;
+      pageCount++;
+    } catch (err) {
+      throw new Error(JSON.stringify(err));
+    }
+  }
+  return repoList;
+};
+
+const getRepos = async (
+  url: string,
+  projectKey: string,
+  token: string,
+  startFrom: number,
+  limit: number,
+): Promise<{
+  repos: BitbucketServerRepoData[];
+  isLastPage: boolean;
+  start: number;
+}> => {
+  let isLastPage = false;
+  let start = 0;
+  const repos: BitbucketServerRepoData[] = [];
+  const { body, statusCode } = await limiter.schedule(() =>
+    needle(
+      'get',
+      `${url}/rest/api/1.0/repos?projectname=${projectKey}&state=AVAILABLE&start=${startFrom}&limit=${limit}`,
+      {
+        headers: { Authorization: 'Bearer ' + token },
+      },
+    ),
+  );
+  if (statusCode != 200) {
+    if (statusCode == 429) {
+      debug(
+        `Failed to fetch page: ${url}/rest/api/1.0/repos?projectname=${projectKey}&state=AVAILABLE&start=${startFrom}&limit=${limit}\n, Response Status: ${JSON.stringify(
+          body,
+        )}\nToo many requests \nWaiting for 3 minutes before resuming`,
+      );
+      await sleepNow(180000);
+      isLastPage = false;
+    } else {
+      throw new Error(
+        `Failed to fetch page: ${url}/rest/api/1.0/repos?projectname=${projectKey}&state=AVAILABLE&start=${startFrom}&limit=${limit}\n, Response Status: ${statusCode}\nResponse Status Text: ${JSON.stringify(
+          body,
+        )} `,
+      );
+    }
+  }
+  const values = body['values'];
+  isLastPage = body['isLastPage'];
+  start = body['nextPageStart'] || -1;
+  for (const repo of values) {
+    repos.push({ projectKey: repo.project.key, repoSlug: repo.name });
+  }
+  return { repos, isLastPage, start };
+};
+
+const sleepNow = (delay: number): unknown =>
+  new Promise((resolve) => setTimeout(resolve, delay));
+
+export async function listBitbucketServerRepos(
+  projectName: string,
+  host: string,
+): Promise<BitbucketServerRepoData[]> {
+  const bitbucketServerToken = getBitbucketServerToken();
+  if (!host) {
+    throw new Error(
+      'Please provide required `sourceUrl` for Bitbucket Server source',
+    );
+  }
+  debug(`Fetching all repos data for org: ${projectName}`);
+  const repoList = await fetchAllRepos(host, projectName, bitbucketServerToken);
+  return repoList;
+}

--- a/src/lib/source-handlers/bitbucket-server/project-is-empty.ts
+++ b/src/lib/source-handlers/bitbucket-server/project-is-empty.ts
@@ -1,0 +1,23 @@
+import { getBitbucketServerToken } from './get-bitbucket-server-token';
+import { fetchAllRepos } from './list-repos';
+
+export async function bitbucketServerProjectIsEmpty(
+  projectKey: string,
+  sourceUrl?: string,
+): Promise<boolean> {
+  const bitbucketServerToken = getBitbucketServerToken();
+  if (!sourceUrl) {
+    throw new Error(
+      'Please provide required `sourceUrl` for Bitbucket Server source',
+    );
+  }
+  const repos = await fetchAllRepos(
+    sourceUrl,
+    projectKey,
+    bitbucketServerToken,
+  );
+  if (!repos || repos.length === 0) {
+    return true;
+  }
+  return false;
+}

--- a/src/lib/source-handlers/bitbucket-server/types.ts
+++ b/src/lib/source-handlers/bitbucket-server/types.ts
@@ -1,0 +1,10 @@
+export interface BitbucketServerRepoData {
+  projectKey: string;
+  repoSlug: string;
+}
+
+export interface BitbucketServerProjectData {
+  key: string;
+  id: string;
+  name: string;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,7 @@ export enum SupportedIntegrationTypesImportData {
   GHE = 'github-enterprise',
   GITLAB = 'gitlab',
   AZURE_REPOS = 'azure-repos',
+  BITBUCKET_SERVER = 'bitbucket-server',
 }
 
 // used to generate import data by connecting to the source via API
@@ -85,6 +86,7 @@ export enum SupportedIntegrationTypesImportOrgData {
   GITHUB = 'github',
   GHE = 'github-enterprise',
   GITLAB = 'gitlab',
+  BITBUCKET_SERVER = 'bitbucket-server',
 }
 
 // used to generate imported targets that exist in Snyk

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -10,6 +10,10 @@ import {
   gitlabGroupIsEmpty,
 } from '../lib/source-handlers/gitlab';
 import {
+  bitbucketServerProjectIsEmpty,
+  listBitbucketServerProjects,
+} from '../lib/source-handlers/bitbucket-server/';
+import {
   CreateOrgData,
   SupportedIntegrationTypesImportOrgData,
 } from '../lib/types';
@@ -19,12 +23,14 @@ const sourceGenerators = {
   [SupportedIntegrationTypesImportOrgData.GITLAB]: listGitlabGroups,
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizations,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubEnterpriseOrganizations,
+  [SupportedIntegrationTypesImportOrgData.BITBUCKET_SERVER]: listBitbucketServerProjects,
 };
 
 const sourceNotEmpty = {
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizationIsEmpty,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubOrganizationIsEmpty,
   [SupportedIntegrationTypesImportOrgData.GITLAB]: gitlabGroupIsEmpty,
+  [SupportedIntegrationTypesImportOrgData.BITBUCKET_SERVER]: bitbucketServerProjectIsEmpty,
 };
 
 export const entityName: {
@@ -33,6 +39,7 @@ export const entityName: {
   github: 'organization',
   'github-enterprise': 'organization',
   gitlab: 'group',
+  'bitbucket-server': 'project',
 };
 
 const exportFileName: {
@@ -41,6 +48,7 @@ const exportFileName: {
   github: 'github-com',
   'github-enterprise': 'github-enterprise',
   gitlab: 'gitlab',
+  'bitbucket-server': 'bitbucket-server',
 };
 
 export async function generateOrgImportDataFile(

--- a/src/scripts/generate-targets-data.ts
+++ b/src/scripts/generate-targets-data.ts
@@ -14,6 +14,8 @@ import {
   GitlabRepoData,
   listAzureRepos,
   AzureRepoData,
+  listBitbucketServerRepos,
+  BitbucketServerRepoData,
 } from '../lib';
 
 const debug = debugLib('snyk:generate-targets-data');
@@ -36,6 +38,7 @@ const sourceGenerators = {
   [SupportedIntegrationTypesImportData.GHE]: githubEnterpriseRepos,
   [SupportedIntegrationTypesImportData.GITLAB]: listGitlabRepos,
   [SupportedIntegrationTypesImportData.AZURE_REPOS]: listAzureRepos,
+  [SupportedIntegrationTypesImportData.BITBUCKET_SERVER]: listBitbucketServerRepos,
 };
 
 function validateRequiredOrgData(
@@ -87,7 +90,10 @@ export async function generateTargetsImportDataFile(
     try {
       validateRequiredOrgData(name, integrations, orgId);
       const entities: Array<
-        GithubRepoData | GitlabRepoData | AzureRepoData
+        | GithubRepoData
+        | GitlabRepoData
+        | AzureRepoData
+        | BitbucketServerRepoData
       > = await sourceGenerators[source](topLevelEntity.name, sourceUrl!);
       entities.forEach((entity) => {
         targetsData.push({

--- a/test/lib/source-handlers/bitbucket-server/bitbucket-server.test.ts
+++ b/test/lib/source-handlers/bitbucket-server/bitbucket-server.test.ts
@@ -1,0 +1,38 @@
+import { string } from 'yargs';
+import { listBitbucketServerProjects } from '../../../../src/lib/source-handlers/bitbucket-server/list-projects';
+import { listBitbucketServerRepos } from '../../../../src/lib/source-handlers/bitbucket-server/list-repos';
+
+jest.setTimeout(60000);
+
+describe('listBitbucketServerProjects script', () => {
+  process.env.BITBUCKET_SERVER_TOKEN = process.env.BBS_TOKEN;
+  const sourceUrl = process.env.BBS_SOURCE_URL!.toString();
+  const bitbucketServerTestOrgName = process.env.BBS_TEST_ORG_NAME!.toString();
+
+  it('listBitbucketServerProjects script', async () => {
+    const projects = await listBitbucketServerProjects(sourceUrl);
+    expect(projects).toBeTruthy();
+    expect(projects[0]).toHaveProperty('key', expect.any(String));
+    expect(projects[0]).toHaveProperty('id', expect.any(Number));
+    expect(projects[0]).toHaveProperty('name', expect.any(String));
+  });
+  it('listBitbucketServerRepos script', async () => {
+    const repos = await listBitbucketServerRepos(
+      bitbucketServerTestOrgName,
+      sourceUrl,
+    );
+    expect(repos).toBeTruthy();
+    expect(repos[0]).toEqual({
+      projectKey: expect.any(String),
+      repoSlug: expect.any(String),
+    });
+  });
+  it('listBitbucketServerRepos script to throw', async () => {
+    expect(async () => {
+      await listBitbucketServerRepos(
+        'non-existing-project',
+        'https://non-existing-url',
+      )}
+      ).rejects.toThrow();
+  });
+});

--- a/test/lib/source-handlers/github/github.test.ts
+++ b/test/lib/source-handlers/github/github.test.ts
@@ -14,7 +14,7 @@ describe('listGithubOrgs script', () => {
       id: expect.any(Number),
       url: expect.any(String),
     });
-  }, 10000);
+  }, 20000);
   it('list orgs GHE', async () => {
     process.env.GITHUB_TOKEN = process.env.TEST_GHE_TOKEN;
     const GHE_URL = process.env.TEST_GHE_URL;
@@ -24,7 +24,7 @@ describe('listGithubOrgs script', () => {
       id: expect.any(Number),
       url: expect.any(String),
     });
-  }, 10000);
+  }, 20000);
 });
 
 describe('listGithubRepos script', () => {
@@ -44,7 +44,7 @@ describe('listGithubRepos script', () => {
       branch: expect.any(String),
       fork: expect.any(Boolean),
     });
-  }, 10000);
+  }, 20000);
   it('list GHE repos', async () => {
     const GITHUB_ORG_NAME = process.env.TEST_GH_ORG_NAME;
     const GHE_URL = process.env.TEST_GHE_URL;
@@ -60,5 +60,5 @@ describe('listGithubRepos script', () => {
       branch: expect.any(String),
       fork: expect.any(Boolean),
     });
-  }, 10000);
+  }, 20000);
 });

--- a/test/scripts/generate-org-data.test.ts
+++ b/test/scripts/generate-org-data.test.ts
@@ -108,7 +108,7 @@ describe('generateOrgImportDataFile Github script', () => {
       name: expect.any(String),
       groupId,
     });
-  }, 50000);
+  }, 80000);
   it('generate Github Enterprise Orgs data & skips empty Orgs', async () => {
     process.env.GITHUB_TOKEN = process.env.TEST_GHE_TOKEN;
     const GHE_URL = process.env.TEST_GHE_URL;
@@ -135,7 +135,7 @@ describe('generateOrgImportDataFile Github script', () => {
       name: expect.any(String),
       groupId,
     });
-  }, 50000);
+  }, 80000);
 });
 
 describe('generateOrgImportDataFile Gitlab script', () => {
@@ -170,7 +170,7 @@ describe('generateOrgImportDataFile Gitlab script', () => {
       name: expect.any(String),
       groupId,
     });
-  }, 50000);
+  }, 80000);
 
   it('generate Gitlab Orgs data and skips empty orgs', async () => {
     process.env.GITLAB_TOKEN = process.env.TEST_GITLAB_TOKEN;

--- a/test/system/__snapshots__/import:data.test.ts.snap
+++ b/test/system/__snapshots__/import:data.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`\`snyk-api-import import:data <...>\` Shows error when missing  1`] = `
 [Error: Command failed: node ./dist/index.js import:data --source=github
+Debugger attached.
 index.js import:data
 
 Generate data required for targets to be imported via API to create Snyk
@@ -11,26 +12,29 @@ projects.
 Options:
   --version          Show version number                               [boolean]
   --help             Show help                                         [boolean]
-  --orgsData         Path to organizations data file generated with "orgs:data"
-                     command                                          [required]
+  --orgsData         Path to organizations data file generated with
+                     "orgs:create" command                            [required]
   --source           The source of the targets to be imported e.g. Github,
                      Github Enterprise, Gitlab, Azure. This will be used to make
                      an API call to list all available entities per org
-    [required] [choices: "github", "github-enterprise", "gitlab", "azure-repos"]
-                                                             [default: "github"]
+    [required] [choices: "github", "github-enterprise", "gitlab", "azure-repos",
+                                         "bitbucket-server"] [default: "github"]
   --sourceUrl        Custom base url for the source API that can list
                      organizations (e.g. Github Enterprise url)
   --integrationType  The configured integration type on the created Snyk Org to
                      use for generating import targets data. Applies to all
                      targets.
-    [required] [choices: "github", "github-enterprise", "gitlab", "azure-repos"]
+    [required] [choices: "github", "github-enterprise", "gitlab", "azure-repos",
+                                                             "bitbucket-server"]
 
 Missing required arguments: orgsData, integrationType
+Waiting for the debugger to disconnect...
 ]
 `;
 
 exports[`\`snyk-api-import import:data <...>\` Shows error when missing  2`] = `
-"index.js import:data
+"Debugger attached.
+index.js import:data
 
 Generate data required for targets to be imported via API to create Snyk
 projects.
@@ -39,21 +43,23 @@ projects.
 Options:
   --version          Show version number                               [boolean]
   --help             Show help                                         [boolean]
-  --orgsData         Path to organizations data file generated with \\"orgs:data\\"
-                     command                                          [required]
+  --orgsData         Path to organizations data file generated with
+                     \\"orgs:create\\" command                            [required]
   --source           The source of the targets to be imported e.g. Github,
                      Github Enterprise, Gitlab, Azure. This will be used to make
                      an API call to list all available entities per org
-    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\"]
-                                                             [default: \\"github\\"]
+    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
+                                         \\"bitbucket-server\\"] [default: \\"github\\"]
   --sourceUrl        Custom base url for the source API that can list
                      organizations (e.g. Github Enterprise url)
   --integrationType  The configured integration type on the created Snyk Org to
                      use for generating import targets data. Applies to all
                      targets.
-    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\"]
+    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
+                                                             \\"bitbucket-server\\"]
 
 Missing required arguments: orgsData, integrationType
+Waiting for the debugger to disconnect...
 "
 `;
 
@@ -67,17 +73,18 @@ projects.
 Options:
   --version          Show version number                               [boolean]
   --help             Show help                                         [boolean]
-  --orgsData         Path to organizations data file generated with \\"orgs:data\\"
-                     command                                          [required]
+  --orgsData         Path to organizations data file generated with
+                     \\"orgs:create\\" command                            [required]
   --source           The source of the targets to be imported e.g. Github,
                      Github Enterprise, Gitlab, Azure. This will be used to make
                      an API call to list all available entities per org
-    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\"]
-                                                             [default: \\"github\\"]
+    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
+                                         \\"bitbucket-server\\"] [default: \\"github\\"]
   --sourceUrl        Custom base url for the source API that can list
                      organizations (e.g. Github Enterprise url)
   --integrationType  The configured integration type on the created Snyk Org to
                      use for generating import targets data. Applies to all
                      targets.
-    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\"]"
+    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
+                                                             \\"bitbucket-server\\"]"
 `;

--- a/test/system/__snapshots__/import:data.test.ts.snap
+++ b/test/system/__snapshots__/import:data.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`\`snyk-api-import import:data <...>\` Shows error when missing  1`] = `
 [Error: Command failed: node ./dist/index.js import:data --source=github
-Debugger attached.
 index.js import:data
 
 Generate data required for targets to be imported via API to create Snyk
@@ -28,13 +27,11 @@ Options:
                                                              "bitbucket-server"]
 
 Missing required arguments: orgsData, integrationType
-Waiting for the debugger to disconnect...
 ]
 `;
 
 exports[`\`snyk-api-import import:data <...>\` Shows error when missing  2`] = `
-"Debugger attached.
-index.js import:data
+"index.js import:data
 
 Generate data required for targets to be imported via API to create Snyk
 projects.
@@ -59,7 +56,6 @@ Options:
                                                              \\"bitbucket-server\\"]
 
 Missing required arguments: orgsData, integrationType
-Waiting for the debugger to disconnect...
 "
 `;
 

--- a/test/system/__snapshots__/orgs:data.test.ts.snap
+++ b/test/system/__snapshots__/orgs:data.test.ts.snap
@@ -2,10 +2,13 @@
 
 exports[`\`snyk-api-import orgs:data <...>\` Generates orgs data as expected 1`] = `"Found 9 organization(s). Written the data to file: group-hello-github-com-orgs.json"`;
 
+exports[`\`snyk-api-import orgs:data <...>\` Generates orgs data as expected for Bitbucket Server 1`] = `"Found 144 project(s). Written the data to file: group-hello-bitbucket-server-orgs.json"`;
+
 exports[`\`snyk-api-import orgs:data <...>\` Generates orgs data as expected for Gitlab 1`] = `"Found 14 group(s). Written the data to file: group-hello-gitlab-orgs.json"`;
 
 exports[`\`snyk-api-import orgs:data <...>\` Shows error when missing groupId 1`] = `
 [Error: Command failed: node ./dist/index.js orgs:data --source=github
+Debugger attached.
 index.js orgs:data
 
 Generate data required for Orgs to be created via API by mirroring a given
@@ -25,10 +28,11 @@ Options:
                        Github Organization does not have any repos)
   --source             The source of the targets to be imported e.g. Github,
                        Github Enterprise
-         [required] [choices: "github", "github-enterprise", "gitlab"] [default:
-                                                                       "github"]
+                   [required] [choices: "github", "github-enterprise", "gitlab",
+                                         "bitbucket-server"] [default: "github"]
 
 Missing required argument: groupId
+Waiting for the debugger to disconnect...
 ]
 `;
 
@@ -52,6 +56,6 @@ Options:
                        Github Organization does not have any repos)
   --source             The source of the targets to be imported e.g. Github,
                        Github Enterprise
-         [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\"] [default:
-                                                                       \\"github\\"]"
+                   [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\",
+                                         \\"bitbucket-server\\"] [default: \\"github\\"]"
 `;

--- a/test/system/__snapshots__/orgs:data.test.ts.snap
+++ b/test/system/__snapshots__/orgs:data.test.ts.snap
@@ -8,7 +8,6 @@ exports[`\`snyk-api-import orgs:data <...>\` Generates orgs data as expected for
 
 exports[`\`snyk-api-import orgs:data <...>\` Shows error when missing groupId 1`] = `
 [Error: Command failed: node ./dist/index.js orgs:data --source=github
-Debugger attached.
 index.js orgs:data
 
 Generate data required for Orgs to be created via API by mirroring a given
@@ -32,7 +31,6 @@ Options:
                                          "bitbucket-server"] [default: "github"]
 
 Missing required argument: groupId
-Waiting for the debugger to disconnect...
 ]
 `;
 

--- a/test/system/import:data.test.ts
+++ b/test/system/import:data.test.ts
@@ -53,6 +53,29 @@ describe('`snyk-api-import import:data <...>`', () => {
       },
     );
   }, 20000);
+  it('Generates repo data as expected for Bitbucket Server', (done) => {
+    const orgDataFile = 'test/system/fixtures/org-data/orgs.json';
+    exec(
+      `node ${main} import:data --source=bitbucket-server --integrationType=bitbucket-server --sourceUrl=${process.env.BBS_SOURCE_URL} --orgsData=${orgDataFile}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          BITBUCKET_SERVER_TOKEN: process.env.BBS_TOKEN,
+          SNYK_LOG_PATH: __dirname,
+        },
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          throw err;
+        }
+        expect(err).toBeNull();
+        expect(stderr).toEqual('');
+        expect(stdout.trim()).toMatch('Written the data to file');
+        deleteFiles([join(__dirname, 'bitbucket-server-import-targets.json')]);
+        done();
+      },
+    );
+  }, 20000);
   it('Shows error when missing ', (done) => {
     exec(`node ${main} import:data --source=github`, (err, stdout, stderr) => {
       expect(err).toMatchSnapshot();

--- a/test/system/orgs:data.test.ts
+++ b/test/system/orgs:data.test.ts
@@ -76,6 +76,29 @@ describe('`snyk-api-import orgs:data <...>`', () => {
       },
     );
   }, 20000);
+  it('Generates orgs data as expected for Bitbucket Server', (done) => {
+    const groupId = 'hello';
+    exec(
+      `node ${main} orgs:data --source=bitbucket-server --groupId=${groupId} --sourceUrl=${process.env.BBS_SOURCE_URL}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          BITBUCKET_SERVER_TOKEN: process.env.BBS_TOKEN,
+          SNYK_LOG_PATH: __dirname,
+        },
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          throw err;
+        }
+        expect(stderr).toEqual('');
+        expect(err).toBeNull();
+        expect(stdout.trim()).toMatchSnapshot();
+        deleteFiles([`group-${groupId}-bitbucket-server-orgs.json`]);
+        done();
+      },
+    );
+  }, 20000);
   it('Shows error when missing groupId', (done) => {
     exec(`node ${main} orgs:data --source=github`, (err, stdout) => {
       expect(err).toMatchSnapshot();


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Adds support for the import:data command to Bitbucket Server