### PR TITLE
feat: orgs data command for bitbucket cloud

### DIFF
--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -4,6 +4,7 @@
 - Generating the data to create Organizations in Snyk
   - [Github](#githubcom--github-enterprise)
   - [Gitlab](#gitlabcom--hosted-gitlab)
+  - [Bitbucket-cloud](#bitbucket-cloud)
 - [Creating the organizations](#creating-organizations-in-snyk-1)
   - [via the API](#via-api)
   - [via the `orgs:create` util](#via-orgscreate-util)
@@ -14,8 +15,8 @@ Before an import can begin Snyk needs to be setup with the Organizations you wil
 It is recommended to have as many Organizations in Snyk as you have in the source you are importing from. So for Github this would mean mirroring the Github organizations in Snyk. The tool provides a utility that can be used to make this simpler when using Groups & Organizations in Snyk.
 
 # Generating the data required to create Organizations in Snyk with `orgs:data` util
-This util helps generate data needed to mirror the Github.com / Github Enterprise organization structure in Snyk.
-This is an opinionated util and will assume every organization in Github.com / Github Enterprise should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
+This util helps generate data needed to mirror the Github.com / Github Enterprise / Bitbucket Cloud organization structure in Snyk.
+This is an opinionated util and will assume every organization in Github.com / Github Enterprise / Bitbucket Cloud should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
 
 ## Github.com / Github Enterprise
 1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
@@ -33,6 +34,15 @@ This will create the organization data in a file `group-<snyk_group_id>-github-<
  - **Hosted Gitlab:** `snyk-api-import orgs:data --source=gitlab --groupId=<snyk_group_id> -- sourceUrl=https://gitlab.custom.com`
 
 This will create the organization data in a file `group-<snyk_group_id>-gitlab-orgs.json`
+
+
+## Bitbucket Cloud
+1. set the bitbucket Cloud Username and Password as an environment variables: `export BITBUCKET_CLOUD_USERNAME=your_bitbucket_cloud_username` and `export BITBUCKET_CLOUD_PASSWORD=your_bitbucket_cloud_password`
+2. Run the command to generate organization data:
+ - `snyk-api-import orgs:data --source=bitbucket-cloud --groupId=<snyk_group_id>`
+
+This will create the organization data in a file `group-<snyk_group_id>-bitbucket-cloud-orgs.json`
+
 
 # Creating Organizations in Snyk
 Use the generated data file to help create the organizations via API or use the provided util.

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -39,7 +39,7 @@ export const builder = {
     default: SupportedIntegrationTypesImportOrgData.GITHUB,
     choices: [...Object.values(SupportedIntegrationTypesImportOrgData)],
     desc:
-      'The source of the targets to be imported e.g. Github, Github Enterprise',
+      'The source of the targets to be imported e.g. Github, Github Enterprise, Gitlab, Bitbucket-server/cloud',
   },
 };
 

--- a/src/lib/source-handlers/bitbucket-cloud/get-bitbucket-cloud-password.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/get-bitbucket-cloud-password.ts
@@ -1,0 +1,9 @@
+export function getBitbucketCloudPassword(): string {
+  const bitbucketCloudPassword = process.env.BITBUCKET_CLOUD_PASSWORD;
+  if (!bitbucketCloudPassword) {
+    throw new Error(
+      `Please set the BITBUCKET_CLOUD_PASSWORD e.g. export BITBUCKET_CLOUD_PASSWORD='mybitbucketCloudPassword'`,
+    );
+  }
+  return bitbucketCloudPassword;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/get-bitbucket-cloud-username.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/get-bitbucket-cloud-username.ts
@@ -1,0 +1,9 @@
+export function getBitbucketCloudUsername(): string {
+  const bitbucketCLoudUsername = process.env.BITBUCKET_CLOUD_USERNAME;
+  if (!bitbucketCLoudUsername) {
+    throw new Error(
+      `Please set the BITBUCKET_CLOUD_USERNAME e.g. export BITBUCKET_CLOUD_USERNAME='myBitbucketCloudUsername'`,
+    );
+  }
+  return bitbucketCLoudUsername;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/index.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/index.ts
@@ -1,0 +1,4 @@
+export * from './list-workspaces';
+export * from './list-repos';
+export * from './workspace-is-empty';
+export * from './types';

--- a/src/lib/source-handlers/bitbucket-cloud/list-repos.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/list-repos.ts
@@ -1,0 +1,67 @@
+import * as needle from 'needle';
+import * as debugLib from 'debug';
+import Bottleneck from 'bottleneck';
+import base64 = require('base-64');
+import { BitbucketCloudRepoData } from './types';
+
+const debug = debugLib('snyk:bitbucket-cloud');
+
+const limiter = new Bottleneck({
+  reservoir: 1000, // initial value
+  reservoirRefreshAmount: 1000,
+  reservoirRefreshInterval: 3600 * 1000,
+  maxConcurrent: 1,
+  minTime: 1000,
+});
+
+limiter.on('failed', async (error, jobInfo) => {
+  const id = jobInfo.options.id;
+  console.warn(`Job ${id} failed: ${error}`);
+  if (jobInfo.retryCount === 0) {
+    // Here we only retry once
+    console.log(`Retrying job ${id} in 25ms!`);
+    return 25;
+  }
+});
+
+export const fetchAllRepos = async (
+  workspace: string,
+  username: string,
+  password: string,
+): Promise<BitbucketCloudRepoData[]> => {
+  let isLastPage = false;
+  let repos: BitbucketCloudRepoData[] = [];
+  let pageCount = 1;
+  while (!isLastPage) {
+    debug(`Fetching page ${pageCount} for ${workspace}\n`);
+    const { statusCode, body } = await limiter.schedule(() =>
+      needle('get', `https://bitbucket.org/api/2.0/repositories/${workspace}`, {
+        headers: {
+          Authorization: 'Basic ' + base64.encode(username + ':' + password),
+        },
+      }),
+    );
+    if (statusCode != 200) {
+      if (statusCode == 429) {
+        debug(
+          `Failed to fetch page: https://bitbucket.org/api/2.0/repositories/${workspace}\n, Response Status: ${body}\nToo many requests \nWaiting for 3 minutes before resuming`,
+        );
+        await sleepNow(180000);
+        isLastPage = false;
+      } else {
+        debug(
+          `Failed to fetch page: https://bitbucket.org/api/2.0/repositories/${workspace}\n, Response Status: ${statusCode}\nResponse Status Text: ${body} `,
+        );
+      }
+    }
+    const apiResponse = body['values'];
+    repos = repos.concat(apiResponse);
+    const next = body['next'];
+    next ? (isLastPage = false) : (isLastPage = true);
+    pageCount++;
+  }
+  return repos;
+};
+
+const sleepNow = (delay: number): unknown =>
+  new Promise((resolve) => setTimeout(resolve, delay));

--- a/src/lib/source-handlers/bitbucket-cloud/list-workspaces.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/list-workspaces.ts
@@ -1,0 +1,81 @@
+import * as needle from 'needle';
+import * as debugLib from 'debug';
+import Bottleneck from 'bottleneck';
+import base64 = require('base-64');
+import { BitbucketCloudWorkspaceData } from './types';
+import { getBitbucketCloudUsername } from './get-bitbucket-cloud-username';
+import { getBitbucketCloudPassword } from './get-bitbucket-cloud-password';
+
+const debug = debugLib('snyk:bitbucket-server');
+
+const limiter = new Bottleneck({
+  reservoir: 1000, // initial value
+  reservoirRefreshAmount: 1000,
+  reservoirRefreshInterval: 3600 * 1000,
+  maxConcurrent: 1,
+  minTime: 1000,
+});
+
+limiter.on('failed', async (error, jobInfo) => {
+  const id = jobInfo.options.id;
+  debug(`Job ${id} failed: ${error}`);
+  if (jobInfo.retryCount === 0) {
+    // Here we only retry once
+    debug(`Retrying job ${id} in 25ms!`);
+    return 25;
+  }
+});
+
+export async function fetchAllWorkspaces(
+  username: string,
+  password: string,
+): Promise<BitbucketCloudWorkspaceData[]> {
+  let isLastPage = false;
+  let workspaces: BitbucketCloudWorkspaceData[] = [];
+  let pageCount = 1;
+  while (!isLastPage) {
+    debug(`Fetching page ${pageCount}\n`);
+    const { statusCode, body } = await limiter.schedule(() =>
+      needle('get', `https://bitbucket.org/api/2.0/workspaces`, {
+        headers: {
+          Authorization: 'Basic ' + base64.encode(username + ':' + password),
+        },
+      }),
+    );
+    if (statusCode != 200) {
+      if (statusCode == 429) {
+        debug(
+          `Failed to fetch page: https://bitbucket.org/api/2.0/workspaces\n, Response Status: ${body}\nToo many requests \nWaiting for 3 minutes before resuming`,
+        );
+        await sleepNow(180000);
+        isLastPage = false;
+      } else {
+        debug(
+          `Failed to fetch page: https://bitbucket.org/api/2.0/workspaces\n, Response Status: ${statusCode}\nResponse Status Text: ${body} `,
+        );
+      }
+    }
+    const apiResponse = body['values'];
+    workspaces = workspaces.concat(apiResponse);
+    const next = body['next'];
+    next ? (isLastPage = false) : (isLastPage = true);
+    pageCount++;
+  }
+  return workspaces;
+}
+
+const sleepNow = (delay: number): unknown =>
+  new Promise((resolve) => setTimeout(resolve, delay));
+
+export async function listBitbucketCloudWorkspaces(): Promise<
+  BitbucketCloudWorkspaceData[]
+> {
+  const bitbucketCloudUsername = getBitbucketCloudUsername();
+  const bitbucketCloudPassword = getBitbucketCloudPassword();
+  debug(`Fetching all projects data`);
+  const workspaces = await fetchAllWorkspaces(
+    bitbucketCloudUsername,
+    bitbucketCloudPassword,
+  );
+  return workspaces;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/types.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/types.ts
@@ -1,0 +1,18 @@
+export interface BitbucketCloudWorkspaceData {
+  uuid: string;
+  slug: string;
+  is_private: boolean;
+  name: string;
+}
+
+export interface BitbucketCloudRepoData {
+  slug: string;
+  workspace: {
+    uuid: string;
+    slug?: string;
+  };
+  mainbranch?: {
+    name: string;
+  };
+  is_private?: boolean;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/workspace-is-empty.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/workspace-is-empty.ts
@@ -1,0 +1,16 @@
+import { getBitbucketCloudUsername } from './get-bitbucket-cloud-username';
+import { getBitbucketCloudPassword } from './get-bitbucket-cloud-password';
+import { fetchAllRepos } from './list-repos';
+
+export async function bitbucketCloudWorkspaceIsEmpty(
+  workspace: string,
+): Promise<boolean> {
+  const bitbucketCloudUsername = getBitbucketCloudUsername();
+  const bitbucketCloudPassword = getBitbucketCloudPassword();
+  const repos = await fetchAllRepos(
+    workspace,
+    bitbucketCloudUsername,
+    bitbucketCloudPassword,
+  );
+  return !repos || repos.length === 0;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,6 +85,7 @@ export enum SupportedIntegrationTypesImportOrgData {
   GITHUB = 'github',
   GHE = 'github-enterprise',
   GITLAB = 'gitlab',
+  BITBUCKET_CLOUD = 'bitbucket-cloud',
 }
 
 // used to generate imported targets that exist in Snyk

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -10,6 +10,10 @@ import {
   gitlabGroupIsEmpty,
 } from '../lib/source-handlers/gitlab';
 import {
+  bitbucketCloudWorkspaceIsEmpty,
+  listBitbucketCloudWorkspaces,
+} from '../lib/source-handlers/bitbucket-cloud';
+import {
   CreateOrgData,
   SupportedIntegrationTypesImportOrgData,
 } from '../lib/types';
@@ -19,12 +23,14 @@ const sourceGenerators = {
   [SupportedIntegrationTypesImportOrgData.GITLAB]: listGitlabGroups,
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizations,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubEnterpriseOrganizations,
+  [SupportedIntegrationTypesImportOrgData.BITBUCKET_CLOUD]: listBitbucketCloudWorkspaces,
 };
 
 const sourceNotEmpty = {
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizationIsEmpty,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubOrganizationIsEmpty,
   [SupportedIntegrationTypesImportOrgData.GITLAB]: gitlabGroupIsEmpty,
+  [SupportedIntegrationTypesImportOrgData.BITBUCKET_CLOUD]: bitbucketCloudWorkspaceIsEmpty,
 };
 
 export const entityName: {
@@ -33,6 +39,7 @@ export const entityName: {
   github: 'organization',
   'github-enterprise': 'organization',
   gitlab: 'group',
+  'bitbucket-cloud': 'workspace',
 };
 
 const exportFileName: {
@@ -41,6 +48,7 @@ const exportFileName: {
   github: 'github-com',
   'github-enterprise': 'github-enterprise',
   gitlab: 'gitlab',
+  'bitbucket-cloud': 'bitbucket-cloud',
 };
 
 export async function generateOrgImportDataFile(

--- a/test/lib/source-handlers/bitbucket-cloud/bitbucket-cloud.test.ts
+++ b/test/lib/source-handlers/bitbucket-cloud/bitbucket-cloud.test.ts
@@ -1,0 +1,16 @@
+import { listBitbucketCloudWorkspaces } from '../../../../src/lib/source-handlers/bitbucket-cloud/list-workspaces';
+
+jest.setTimeout(60000);
+
+describe('Test Bitbucket Cloud script', () => {
+  process.env.BITBUCKET_CLOUD_USERNAME = process.env.BBC_USERNAME;
+  process.env.BITBUCKET_CLOUD_PASSWORD = process.env.BBC_PASSWORD;
+
+  it('listBitbucketCloudWorkspaces script', async () => {
+    const workspaces = await listBitbucketCloudWorkspaces();
+    expect(workspaces).toBeTruthy();
+    expect(workspaces[0]).toHaveProperty('uuid', expect.any(String));
+    expect(workspaces[0]).toHaveProperty('slug', expect.any(String));
+    expect(workspaces[0]).toHaveProperty('name', expect.any(String));
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Adds support for the orgs:data command for Bitbucket Cloud

### Notes for the reviewer

Please note that:
- The import:data command will be added on top of this branch
- The list:orgs command is already supported so only the import:data command is left for full coverage

### More information
[Jira Task](https://snyksec.atlassian.net/browse/TECHSERV-1666)
