### PR TITLE
feat: `import:data` command for Bitbucket Cloud

### DIFF
--- a/src/cmds/import:data.ts
+++ b/src/cmds/import:data.ts
@@ -46,6 +46,7 @@ const entityName: {
   gitlab: 'group',
   'azure-repos': 'org',
   'bitbucket-server': 'project',
+  'bitbucket-cloud': 'workspace',
 };
 
 export async function handler(argv: {

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -39,7 +39,7 @@ export const builder = {
     default: SupportedIntegrationTypesImportOrgData.GITHUB,
     choices: [...Object.values(SupportedIntegrationTypesImportOrgData)],
     desc:
-      'The source of the targets to be imported e.g. Github, Github Enterprise, Gitlab, Bitbucket-server',
+      'The source of the targets to be imported e.g. Github, Github Enterprise, Gitlab, Bitbucket Server',
   },
 };
 

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -39,7 +39,7 @@ export const builder = {
     default: SupportedIntegrationTypesImportOrgData.GITHUB,
     choices: [...Object.values(SupportedIntegrationTypesImportOrgData)],
     desc:
-      'The source of the targets to be imported e.g. Github, Github Enterprise',
+      'The source of the targets to be imported e.g. Github, Github Enterprise, Gitlab, Bitbucket-server',
   },
 };
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,3 +15,4 @@ export * from './source-handlers/github';
 export * from './source-handlers/gitlab';
 export * from './source-handlers/azure';
 export * from './source-handlers/bitbucket-server';
+export * from './source-handlers/bitbucket-cloud';

--- a/src/lib/request-with-rate-limit.ts
+++ b/src/lib/request-with-rate-limit.ts
@@ -33,7 +33,9 @@ export async function limiterWithRateLimitRetries(
     }
     if (data.statusCode === 401) {
       console.error(
-        `ERROR: ${data.body}. Please check the token and try again.`,
+        `ERROR: ${JSON.stringify(
+          data.body,
+        )}. Please check the token and try again.`,
       );
       break;
     }

--- a/src/lib/source-handlers/bitbucket-cloud/get-bitbucket-cloud-password.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/get-bitbucket-cloud-password.ts
@@ -1,0 +1,9 @@
+export function getBitbucketCloudPassword(): string {
+  const bitbucketCloudPassword = process.env.BITBUCKET_CLOUD_PASSWORD;
+  if (!bitbucketCloudPassword) {
+    throw new Error(
+      `Please set the BITBUCKET_CLOUD_PASSWORD e.g. export BITBUCKET_CLOUD_PASSWORD='mybitbucketCloudPassword'`,
+    );
+  }
+  return bitbucketCloudPassword;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/get-bitbucket-cloud-username.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/get-bitbucket-cloud-username.ts
@@ -1,0 +1,9 @@
+export function getBitbucketCloudUsername(): string {
+  const bitbucketCLoudUsername = process.env.BITBUCKET_CLOUD_USERNAME;
+  if (!bitbucketCLoudUsername) {
+    throw new Error(
+      `Please set the BITBUCKET_CLOUD_USERNAME e.g. export BITBUCKET_CLOUD_USERNAME='myBitbucketCloudUsername'`,
+    );
+  }
+  return bitbucketCLoudUsername;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/index.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/index.ts
@@ -1,0 +1,4 @@
+export * from './list-workspaces';
+export * from './list-repos';
+export * from './workspace-is-empty';
+export * from './types';

--- a/src/lib/source-handlers/bitbucket-cloud/list-repos.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/list-repos.ts
@@ -1,0 +1,91 @@
+import * as debugLib from 'debug';
+import base64 = require('base-64');
+import { OutgoingHttpHeaders } from 'http2';
+import { BitbucketCloudRepoData } from './types';
+import { getBitbucketCloudUsername } from './get-bitbucket-cloud-username';
+import { getBitbucketCloudPassword } from './get-bitbucket-cloud-password';
+import { limiterForScm } from '../../limiters';
+import { limiterWithRateLimitRetries } from '../../request-with-rate-limit';
+
+const debug = debugLib('snyk:bitbucket-cloud');
+
+export const fetchAllBitbucketCloudRepos = async (
+  workspace: string,
+  username: string,
+  password: string,
+): Promise<BitbucketCloudRepoData[]> => {
+  let lastPage = false;
+  let reposList: BitbucketCloudRepoData[] = [];
+  let pageCount = 1;
+  let nextPage = '';
+  while (!lastPage) {
+    debug(`Fetching page ${pageCount} for ${workspace}\n`);
+    try {
+      const { repos, next } = await getRepos(
+        workspace,
+        username,
+        password,
+        nextPage,
+      );
+
+      reposList = reposList.concat(repos);
+      next
+        ? ((lastPage = false), (nextPage = next))
+        : ((lastPage = true), (nextPage = ''));
+      pageCount++;
+    } catch (err) {
+      throw new Error(JSON.stringify(err));
+    }
+  }
+  return reposList;
+};
+
+const getRepos = async (
+  workspace: string,
+  username: string,
+  password: string,
+  nextPage: string,
+): Promise<{ repos: BitbucketCloudRepoData[]; next: string }> => {
+  const repos: BitbucketCloudRepoData[] = [];
+  const headers: OutgoingHttpHeaders = {
+    Authorization: `Basic ${base64.encode(username + ':' + password)}`,
+  };
+  const limiter = await limiterForScm(1, 1000, 1000, 1000, 1000 * 3600);
+  const { statusCode, body } = await limiterWithRateLimitRetries(
+    'get',
+    nextPage ?? `https://bitbucket.org/api/2.0/repositories/${workspace}`,
+    headers,
+    limiter,
+    60000,
+  );
+  if (statusCode != 200) {
+    throw new Error(`Failed to fetch projects for ${nextPage ??
+      `https://bitbucket.org/api/2.0/repositories/${workspace}`}\n
+      Status Code: ${statusCode}\n
+      Response body: ${JSON.stringify(body)}`);
+  }
+  const values = body['values'];
+  const next = body['next'] ?? '';
+  for (const repo of values) {
+    repos.push({
+      owner: repo.workspace.slug ? repo.workspace.slug : repo.workspace.uuid,
+      name: repo.slug,
+      branch: repo.mainbranch.name ? repo.mainbranch.name : '',
+    });
+  }
+  return { repos, next };
+};
+
+export async function listBitbucketCloudRepos(
+  workspace: string,
+): Promise<BitbucketCloudRepoData[]> {
+  const bitbucketCloudUsername = getBitbucketCloudUsername();
+  const bitbucketCloudPassword = getBitbucketCloudPassword();
+  debug(`Fetching all repos data for org: ${workspace}`);
+  const repoList = await fetchAllBitbucketCloudRepos(
+    workspace,
+    bitbucketCloudUsername,
+    bitbucketCloudPassword,
+  );
+  return repoList;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/list-workspaces.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/list-workspaces.ts
@@ -1,0 +1,88 @@
+import * as debugLib from 'debug';
+import { OutgoingHttpHeaders } from 'http2';
+import base64 = require('base-64');
+import { BitbucketCloudWorkspaceData } from './types';
+import { getBitbucketCloudUsername } from './get-bitbucket-cloud-username';
+import { getBitbucketCloudPassword } from './get-bitbucket-cloud-password';
+import { limiterForScm } from '../../limiters';
+import { limiterWithRateLimitRetries } from '../../request-with-rate-limit';
+
+const debug = debugLib('snyk:bitbucket-cloud');
+
+export async function fetchAllWorkspaces(
+  username: string,
+  password: string,
+): Promise<BitbucketCloudWorkspaceData[]> {
+  let lastPage = false;
+  let workspacesList: BitbucketCloudWorkspaceData[] = [];
+  let pageCount = 1;
+  let nextPage = '';
+  while (!lastPage) {
+    debug(`Fetching page ${pageCount}\n`);
+    try {
+      const { workspaces, next } = await getWorkspaces(
+        username,
+        password,
+        nextPage,
+      );
+      workspacesList = workspacesList.concat(workspaces);
+      next
+        ? ((lastPage = false), (nextPage = next))
+        : ((lastPage = true), (nextPage = ''));
+      pageCount++;
+    } catch (err) {
+      throw new Error(JSON.stringify(err));
+    }
+  }
+  return workspacesList;
+}
+
+export async function getWorkspaces(
+  username: string,
+  password: string,
+  nextPage: string,
+): Promise<{ workspaces: BitbucketCloudWorkspaceData[]; next: string }> {
+  const workspaces: BitbucketCloudWorkspaceData[] = [];
+  const headers: OutgoingHttpHeaders = {
+    Authorization: `Basic ${base64.encode(username + ':' + password)}`,
+  };
+  const limiter = await limiterForScm(1, 1000, 1000, 1000, 1000 * 3600);
+  let next = '';
+  const { statusCode, body } = await limiterWithRateLimitRetries(
+    'get',
+    nextPage != '' ? nextPage : 'https://bitbucket.org/api/2.0/workspaces',
+    headers,
+    limiter,
+    60000,
+  );
+  if (statusCode != 200) {
+    throw new Error(`Failed to fetch projects for ${
+      nextPage != '' ? nextPage : 'https://bitbucket.org/api/2.0/workspaces'
+    }\n
+      Status Code: ${statusCode}\n
+      Response body: ${JSON.stringify(body)}`);
+  }
+  const values = body['values'];
+  next = body['next'];
+  for (const workspace of values) {
+    workspaces.push({
+      name: workspace.slug,
+      slug: workspace.slug,
+      uuid: workspace.uuid,
+    });
+  }
+  return { workspaces, next };
+}
+
+export async function listBitbucketCloudWorkspaces(): Promise<
+  BitbucketCloudWorkspaceData[]
+> {
+  const bitbucketCloudUsername = getBitbucketCloudUsername();
+  const bitbucketCloudPassword = getBitbucketCloudPassword();
+  debug(`Fetching all workspaces data`);
+  const workspaces = await fetchAllWorkspaces(
+    bitbucketCloudUsername,
+    bitbucketCloudPassword,
+  );
+  return workspaces;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/types.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/types.ts
@@ -1,0 +1,11 @@
+export interface BitbucketCloudWorkspaceData {
+  uuid: string;
+  slug: string;
+  name: string;
+}
+
+export interface BitbucketCloudRepoData {
+  owner: string;
+  name: string;
+  branch: string;
+}

--- a/src/lib/source-handlers/bitbucket-cloud/workspace-is-empty.ts
+++ b/src/lib/source-handlers/bitbucket-cloud/workspace-is-empty.ts
@@ -1,0 +1,16 @@
+import { getBitbucketCloudUsername } from './get-bitbucket-cloud-username';
+import { getBitbucketCloudPassword } from './get-bitbucket-cloud-password';
+import { fetchAllBitbucketCloudRepos } from './list-repos';
+
+export async function bitbucketCloudWorkspaceIsEmpty(
+  workspace: string,
+): Promise<boolean> {
+  const bitbucketCloudUsername = getBitbucketCloudUsername();
+  const bitbucketCloudPassword = getBitbucketCloudPassword();
+  const repos = await fetchAllBitbucketCloudRepos(
+    workspace,
+    bitbucketCloudUsername,
+    bitbucketCloudPassword,
+  );
+  return !repos || repos.length === 0;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,7 @@ export enum SupportedIntegrationTypesImportData {
   GITLAB = 'gitlab',
   AZURE_REPOS = 'azure-repos',
   BITBUCKET_SERVER = 'bitbucket-server',
+  BITBUCKET_CLOUD = 'bitbucket-cloud',
 }
 
 // used to generate import data by connecting to the source via API

--- a/src/scripts/generate-targets-data.ts
+++ b/src/scripts/generate-targets-data.ts
@@ -16,6 +16,7 @@ import {
   AzureRepoData,
   listBitbucketServerRepos,
   BitbucketServerRepoData,
+  listBitbucketCloudRepos,
 } from '../lib';
 
 const debug = debugLib('snyk:generate-targets-data');
@@ -39,6 +40,7 @@ const sourceGenerators = {
   [SupportedIntegrationTypesImportData.GITLAB]: listGitlabRepos,
   [SupportedIntegrationTypesImportData.AZURE_REPOS]: listAzureRepos,
   [SupportedIntegrationTypesImportData.BITBUCKET_SERVER]: listBitbucketServerRepos,
+  [SupportedIntegrationTypesImportData.BITBUCKET_CLOUD]: listBitbucketCloudRepos,
 };
 
 function validateRequiredOrgData(

--- a/test/lib/request-with-rate-limit.test.ts
+++ b/test/lib/request-with-rate-limit.test.ts
@@ -1,7 +1,6 @@
 import * as nock from 'nock';
 import Bottleneck from 'bottleneck';
 import { limiterWithRateLimitRetries } from '../../src/lib/request-with-rate-limit';
-import { limiterForScm } from '../../src/lib/limiters';
 
 beforeEach(() => {
   return nock('https://testUrlOkResponse')
@@ -40,6 +39,6 @@ describe('Testing requestWithRateLimitRetries', () => {
       limiter,
       600,
     );
-    expect(data.body.toString()).toEqual('Rate limit reached');
+    expect((data as any).body.toString()).toEqual('Rate limit reached');
   }, 20000);
 });

--- a/test/lib/source-handlers/bitbucket-cloud/bitbucket-cloud.test.ts
+++ b/test/lib/source-handlers/bitbucket-cloud/bitbucket-cloud.test.ts
@@ -1,0 +1,29 @@
+import { listBitbucketCloudWorkspaces } from '../../../../src/lib/source-handlers/bitbucket-cloud/list-workspaces';
+import { listBitbucketCloudRepos } from '../../../../src/lib/source-handlers/bitbucket-cloud/list-repos';
+
+describe('Test Bitbucket Cloud script', () => {
+  process.env.BITBUCKET_CLOUD_USERNAME = process.env.BBC_USERNAME;
+  process.env.BITBUCKET_CLOUD_PASSWORD = process.env.BBC_PASSWORD;
+
+  it('listBitbucketCloudWorkspaces script', async () => {
+    const workspaces = await listBitbucketCloudWorkspaces();
+    expect(workspaces).toBeTruthy();
+    expect(workspaces[0]).toHaveProperty('uuid', expect.any(String));
+    expect(workspaces[0]).toHaveProperty('slug', expect.any(String));
+    expect(workspaces[0]).toHaveProperty('name', expect.any(String));
+  }, 60000);
+  it('listBitbucketCloudRepos script', async () => {
+    const repos = await listBitbucketCloudRepos('snyktestscmgroup');
+    expect(repos).toBeTruthy();
+    expect(repos[0]).toEqual({
+      name: expect.any(String),
+      owner: expect.any(String),
+      branch: expect.any(String),
+    });
+  });
+  it('listBitbucketCloudRepos script to throw', async () => {
+    expect(async () => {
+      await listBitbucketCloudRepos('non-existing-project');
+    }).rejects.toThrow();
+  });
+});

--- a/test/lib/source-handlers/bitbucket-server/bitbucket-server.test.ts
+++ b/test/lib/source-handlers/bitbucket-server/bitbucket-server.test.ts
@@ -1,4 +1,3 @@
-import { string } from 'yargs';
 import { listBitbucketServerProjects } from '../../../../src/lib/source-handlers/bitbucket-server/list-projects';
 import { listBitbucketServerRepos } from '../../../../src/lib/source-handlers/bitbucket-server/list-repos';
 

--- a/test/system/__snapshots__/import:data.test.ts.snap
+++ b/test/system/__snapshots__/import:data.test.ts.snap
@@ -17,14 +17,14 @@ Options:
                      Github Enterprise, Gitlab, Azure. This will be used to make
                      an API call to list all available entities per org
     [required] [choices: "github", "github-enterprise", "gitlab", "azure-repos",
-                                         "bitbucket-server"] [default: "github"]
+                      "bitbucket-server", "bitbucket-cloud"] [default: "github"]
   --sourceUrl        Custom base url for the source API that can list
                      organizations (e.g. Github Enterprise url)
   --integrationType  The configured integration type on the created Snyk Org to
                      use for generating import targets data. Applies to all
                      targets.
     [required] [choices: "github", "github-enterprise", "gitlab", "azure-repos",
-                                                             "bitbucket-server"]
+                                          "bitbucket-server", "bitbucket-cloud"]
 
 Missing required arguments: orgsData, integrationType
 ]
@@ -46,14 +46,14 @@ Options:
                      Github Enterprise, Gitlab, Azure. This will be used to make
                      an API call to list all available entities per org
     [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
-                                         \\"bitbucket-server\\"] [default: \\"github\\"]
+                      \\"bitbucket-server\\", \\"bitbucket-cloud\\"] [default: \\"github\\"]
   --sourceUrl        Custom base url for the source API that can list
                      organizations (e.g. Github Enterprise url)
   --integrationType  The configured integration type on the created Snyk Org to
                      use for generating import targets data. Applies to all
                      targets.
     [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
-                                                             \\"bitbucket-server\\"]
+                                          \\"bitbucket-server\\", \\"bitbucket-cloud\\"]
 
 Missing required arguments: orgsData, integrationType
 "
@@ -75,12 +75,12 @@ Options:
                      Github Enterprise, Gitlab, Azure. This will be used to make
                      an API call to list all available entities per org
     [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
-                                         \\"bitbucket-server\\"] [default: \\"github\\"]
+                      \\"bitbucket-server\\", \\"bitbucket-cloud\\"] [default: \\"github\\"]
   --sourceUrl        Custom base url for the source API that can list
                      organizations (e.g. Github Enterprise url)
   --integrationType  The configured integration type on the created Snyk Org to
                      use for generating import targets data. Applies to all
                      targets.
     [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
-                                                             \\"bitbucket-server\\"]"
+                                          \\"bitbucket-server\\", \\"bitbucket-cloud\\"]"
 `;

--- a/test/system/__snapshots__/import:data.test.ts.snap
+++ b/test/system/__snapshots__/import:data.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`\`snyk-api-import import:data <...>\` Shows error when missing  1`] = `
+exports[`\`snyk-api-import import:data <...>\` Shows error when missing source type 1`] = `
 [Error: Command failed: node ./dist/index.js import:data --source=github
 index.js import:data
 
@@ -30,7 +30,7 @@ Missing required arguments: orgsData, integrationType
 ]
 `;
 
-exports[`\`snyk-api-import import:data <...>\` Shows error when missing  2`] = `
+exports[`\`snyk-api-import import:data <...>\` Shows error when missing source type 2`] = `
 "index.js import:data
 
 Generate data required for targets to be imported via API to create Snyk

--- a/test/system/__snapshots__/orgs:data.test.ts.snap
+++ b/test/system/__snapshots__/orgs:data.test.ts.snap
@@ -26,7 +26,7 @@ Options:
   --skipEmptyOrgs      Skip any organizations that do not any targets. (e.g.
                        Github Organization does not have any repos)
   --source             The source of the targets to be imported e.g. Github,
-                       Github Enterprise, Gitlab, Bitbucket-server
+                       Github Enterprise, Gitlab, Bitbucket Server
                    [required] [choices: "github", "github-enterprise", "gitlab",
                                          "bitbucket-server"] [default: "github"]
 
@@ -53,7 +53,7 @@ Options:
   --skipEmptyOrgs      Skip any organizations that do not any targets. (e.g.
                        Github Organization does not have any repos)
   --source             The source of the targets to be imported e.g. Github,
-                       Github Enterprise, Gitlab, Bitbucket-server
+                       Github Enterprise, Gitlab, Bitbucket Server
                    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\",
                                          \\"bitbucket-server\\"] [default: \\"github\\"]"
 `;

--- a/test/system/__snapshots__/orgs:data.test.ts.snap
+++ b/test/system/__snapshots__/orgs:data.test.ts.snap
@@ -26,7 +26,7 @@ Options:
   --skipEmptyOrgs      Skip any organizations that do not any targets. (e.g.
                        Github Organization does not have any repos)
   --source             The source of the targets to be imported e.g. Github,
-                       Github Enterprise
+                       Github Enterprise, Gitlab, Bitbucket-server
                    [required] [choices: "github", "github-enterprise", "gitlab",
                                          "bitbucket-server"] [default: "github"]
 
@@ -53,7 +53,7 @@ Options:
   --skipEmptyOrgs      Skip any organizations that do not any targets. (e.g.
                        Github Organization does not have any repos)
   --source             The source of the targets to be imported e.g. Github,
-                       Github Enterprise
+                       Github Enterprise, Gitlab, Bitbucket-server
                    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\",
                                          \\"bitbucket-server\\"] [default: \\"github\\"]"
 `;

--- a/test/system/fixtures/org-data/bitbucket-cloud-orgs.json
+++ b/test/system/fixtures/org-data/bitbucket-cloud-orgs.json
@@ -1,0 +1,11 @@
+{
+  "orgData": [
+    {
+      "name": "snyktestscmgroup",
+      "orgId": "<snyk_org_id>",
+      "integrations": {
+        "bitbucket-cloud": "<snyk_org_integration_id>"
+      }
+    }
+  ]
+}

--- a/test/system/import:data.test.ts
+++ b/test/system/import:data.test.ts
@@ -77,7 +77,32 @@ describe('`snyk-api-import import:data <...>`', () => {
       },
     );
   }, 50000);
-  it('Shows error when missing ', (done) => {
+  it('Generates repo data as expected for Bitbucket Cloud', (done) => {
+    const orgDataFile =
+      'test/system/fixtures/org-data/bitbucket-cloud-orgs.json';
+    exec(
+      `node ${main} import:data --source=bitbucket-cloud --integrationType=bitbucket-cloud --orgsData=${orgDataFile}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          BITBUCKET_CLOUD_USERNAME: process.env.BBC_USERNAME,
+          BITBUCKET_CLOUD_PASSWORD: process.env.BBC_PASSWORD,
+          SNYK_LOG_PATH: __dirname,
+        },
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          throw err;
+        }
+        expect(err).toBeNull();
+        expect(stderr).toEqual('');
+        expect(stdout.trim()).toMatch('Written the data to file');
+        deleteFiles([join(__dirname, 'bitbucket-cloud-import-targets.json')]);
+        done();
+      },
+    );
+  }, 50000);
+  it('Shows error when missing source type', (done) => {
     exec(`node ${main} import:data --source=github`, (err, stdout, stderr) => {
       expect(err).toMatchSnapshot();
       expect(stderr).toMatchSnapshot();


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Support for Bitbucket Cloud in `import:data` command to help generate the targets data needed to kick off import.
This will list all repos in the given orgs (provided in the orgs data file) to be imported into the matching orgs in Snyk
