### PR TITLE
fix: add catch to azure api calls and resturcture functions

### DIFF
--- a/src/lib/source-handlers/azure/list-projects.ts
+++ b/src/lib/source-handlers/azure/list-projects.ts
@@ -35,23 +35,27 @@ async function fetchAllProjects(
   let nextPage: string | undefined;
   while (hasMorePages) {
     debug(`Fetching page ${displayPageNumber} for Azure projects`);
-    const { projects, continueFrom } = await getProjects(
-      orgName,
-      host,
-      nextPage,
-    );
-    if (continueFrom && projects.length > 0) {
-      nextPage = continueFrom;
-      displayPageNumber++;
-    } else {
-      hasMorePages = false;
-    }
-    projects.map((project) => {
-      const { name, id } = project;
-      if (name && id) {
-        projectList.push({ id, name });
+    try {
+      const { projects, continueFrom } = await getProjects(
+        orgName,
+        host,
+        nextPage,
+      );
+      if (continueFrom && projects.length > 0) {
+        nextPage = continueFrom;
+        displayPageNumber++;
+      } else {
+        hasMorePages = false;
       }
-    });
+      projects.map((project) => {
+        const { name, id } = project;
+        if (name && id) {
+          projectList.push({ id, name });
+        }
+      });
+    } catch (err) {
+      throw new Error(JSON.stringify(err));
+    }
   }
   return projectList;
 }

--- a/src/lib/source-handlers/azure/list-repos.ts
+++ b/src/lib/source-handlers/azure/list-repos.ts
@@ -31,6 +31,21 @@ export async function fetchAllRepos(
   token: string,
 ): Promise<AzureRepoData[]> {
   debug('Fetching repos for ' + project);
+  let repoList: AzureRepoData[] = [];
+  try {
+    repoList = await getRepos(url, orgName, project, token);
+  } catch (err) {
+    throw new Error(JSON.stringify(err));
+  }
+  return repoList;
+}
+
+async function getRepos(
+  url: string,
+  orgName: string,
+  project: string,
+  token: string,
+): Promise<AzureRepoData[]> {
   const repoList: AzureRepoData[] = [];
   const data = await limiter.schedule(() =>
     needle(

--- a/test/lib/source-handlers/azure/azure.test.ts
+++ b/test/lib/source-handlers/azure/azure.test.ts
@@ -72,4 +72,9 @@ describe('Testing azure-devops interaction', () => {
     const repos = await listAzureRepos('reposTestOrg', 'https://azure-tests');
     expect(repos).toHaveLength(3);
   });
+  test('listAzureRepos to fail', async () => {
+    expect(async () => {
+      await listAzureRepos('non-existing-org', 'https://non-existing-url')}
+      ).rejects.toThrow();
+  });
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Adds try/catch to the azure calls to catch failed calls.

### Notes for the reviewer
[Jira Ticket](https://snyksec.atlassian.net/browse/TECHSERV-1680)