### PR TITLE
fix: write existing orgs file if asked

### DIFF
--- a/src/scripts/create-orgs.ts
+++ b/src/scripts/create-orgs.ts
@@ -201,7 +201,7 @@ export async function createOrgs(
     createdOrgs.push(...created);
   }
 
-  if (createdOrgs.length === 0) {
+  if (createdOrgs.length === 0 && !includeExistingOrgsInOutput) {
     throw new Error(
       `All requested organizations failed to be created. Review the errors in ${path.resolve(
         __dirname,

--- a/test/system/orgs:create.test.ts
+++ b/test/system/orgs:create.test.ts
@@ -58,7 +58,7 @@ describe('`snyk-api-import help <...>`', () => {
         done();
       },
     );
-  }, 10000);
+  }, 20000);
 
   it('Fails to create orgs in --noDuplicateNames mode when org already exists ', (done) => {
     const pathToBadJson = path.resolve(
@@ -68,7 +68,7 @@ describe('`snyk-api-import help <...>`', () => {
       __dirname + '/fixtures/create-orgs/fails-to-create/already-exists',
     );
     exec(
-      `node ${main} orgs:create --file=${pathToBadJson} --noDuplicateNames`,
+      `node ${main} orgs:create --file=${pathToBadJson} --noDuplicateNames --no-includeExistingOrgsInOutput`,
       {
         env: {
           PATH: process.env.PATH,
@@ -95,5 +95,5 @@ describe('`snyk-api-import help <...>`', () => {
         done();
       },
     );
-  }, 10000);
+  }, 20000);
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Fix for a bug that was preventing existing orgs to be written to file of no orgs were created.
