### PR TITLE
test: bust jest cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
                 message: Starting snyk-api-import build-test-monitor job
             - checkout
             - run: npm install
+            - run: npx jest --clearCache
             - run: npm test
             - snyk/scan:
                 fail-on-issues: true

--- a/test/system/fixtures/create-orgs/fails-to-create/1-org.json
+++ b/test/system/fixtures/create-orgs/fails-to-create/1-org.json
@@ -2,7 +2,7 @@
   "orgs": [
     {
       "groupId": "abc",
-      "name": ""
+      "name": "some-name"
     }
   ]
 }

--- a/test/system/orgs:create.test.ts
+++ b/test/system/orgs:create.test.ts
@@ -31,7 +31,7 @@ describe('`snyk-api-import help <...>`', () => {
     );
 
     exec(
-      `node ${main} orgs:create --file=${pathToBadJson}`,
+      `node ${main} orgs:create --file=${pathToBadJson} --noDuplicateNames --no-includeExistingOrgsInOutput`,
       {
         env: {
           PATH: process.env.PATH,
@@ -52,17 +52,18 @@ describe('`snyk-api-import help <...>`', () => {
         const file = fs.readFileSync(
           path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`),
           'utf8',
-        )
-        expect(file).toContain('group not found');
+        );
+        expect(file).toContain('Please provide the group public id');
         deleteFiles([path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`)]);
         done();
       },
     );
-  }, 20000);
+  }, 40000);
 
   it('Fails to create orgs in --noDuplicateNames mode when org already exists ', (done) => {
     const pathToBadJson = path.resolve(
-      __dirname + '/fixtures/create-orgs/fails-to-create/already-exists/1-org.json',
+      __dirname +
+        '/fixtures/create-orgs/fails-to-create/already-exists/1-org.json',
     );
     const logPath = path.resolve(
       __dirname + '/fixtures/create-orgs/fails-to-create/already-exists',
@@ -89,9 +90,11 @@ describe('`snyk-api-import help <...>`', () => {
         const file = fs.readFileSync(
           path.resolve(logPath, `${GROUP_ID}.${FAILED_ORG_LOG_NAME}`),
           'utf8',
-        )
+        );
         expect(file).toContain('Refusing to create a duplicate organization');
-        deleteFiles([path.resolve(logPath, `${GROUP_ID}.${FAILED_ORG_LOG_NAME}`)]);
+        deleteFiles([
+          path.resolve(logPath, `${GROUP_ID}.${FAILED_ORG_LOG_NAME}`),
+        ]);
         done();
       },
     );


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
- bust jest cache to ensure fresh e2e system tests
- update test assertions for API that had it's error updated
