### PR TITLE
Dosc/updateDocumentation

### DIFF
--- a/docs/mirror-bitbucket-server.md
+++ b/docs/mirror-bitbucket-server.md
@@ -15,6 +15,6 @@ Once initial import is complete you may want to periodically check for new repos
 2. Generate organization data in Snyk and skip any that do not have any repos via `--skipEmptyOrg` `snyk-api-import orgs:data --source=bitbucket-server --groupId=<snyk_group_id> --skipEmptyOrg` [Full instructions](./orgs.md)
 3. Create organizations in Snyk and this time skip any that have been created already with `--noDuplicateNames` parameter `snyk-api-import orgs:create --file=orgs.json --noDuplicateNames` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
 4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-server --integrationType=bitbucket-server` [Full instructions](./import-data.md)
-5. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
+5. Optional. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
 6. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)

--- a/docs/mirror-github.md
+++ b/docs/mirror-github.md
@@ -15,6 +15,6 @@ Once initial import is complete you may want to periodically check for new repos
 2. Generate organization data in Snyk and skip any that do not have any repos via `--skipEmptyOrg` `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id> --skipEmptyOrg` [Full instructions](./orgs.md)
 3. Create organizations in Snyk and this time skip any that have been created already with `--noDuplicateNames` parameter `snyk-api-import orgs:create --file=orgs.json --noDuplicateNames` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
 4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=github --integrationType=github` [Full instructions](./import-data.md)
-5. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
+5. Optional. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
 6. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)

--- a/docs/mirror-gitlab.md
+++ b/docs/mirror-gitlab.md
@@ -15,6 +15,6 @@ Once initial import is complete you may want to periodically check for new repos
 2. Generate organization data in Snyk and skip any that do not have any repos via `--skipEmptyOrg` `snyk-api-import orgs:data --source=gitlab --groupId=<snyk_group_id> --skipEmptyOrg` [Full instructions](./orgs.md)
 3. Create organizations in Snyk and this time skip any that have been created already with `--noDuplicateNames` parameter `snyk-api-import orgs:create --file=orgs.json --noDuplicateNames` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
 4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=gitlab --integrationType=gitlab` [Full instructions](./import-data.md)
-5. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
+5. Optional. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
 `snyk-api-import-macos list:imported --integrationType=gitlab --groupId=<snyk_group_id>`
 6. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

Update the documentation to make it clear that the step 5 (Generate the previously imported log) of each mirror command is optional and can be skipped.

https://snyksec.atlassian.net/browse/TECHSERV-1717