### PR TITLE
Feat/orgs data command for bitbucket cloud

### DIFF
--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -4,7 +4,8 @@
 - Generating the data to create Organizations in Snyk
   - [Github](#githubcom--github-enterprise)
   - [Gitlab](#gitlabcom--hosted-gitlab)
-  - [Bitbucket Server](#bitbucket-server)
+  - [Bitbucket-Server](#bitbucket-server)
+  - [Bitbucket-cloud](#bitbucket-cloud)
 - [Creating the organizations](#creating-organizations-in-snyk-1)
   - [via the API](#via-api)
   - [via the `orgs:create` util](#via-orgscreate-util)
@@ -15,8 +16,8 @@ Before an import can begin Snyk needs to be setup with the Organizations you wil
 It is recommended to have as many Organizations in Snyk as you have in the source you are importing from. So for Github this would mean mirroring the Github organizations in Snyk. The tool provides a utility that can be used to make this simpler when using Groups & Organizations in Snyk.
 
 # Generating the data required to create Organizations in Snyk with `orgs:data` util
-This util helps generate data needed to mirror the Github.com / Github Enterprise / Gitlab / Bitbucket Server organization structure in Snyk.
-This is an opinionated util and will assume every organization in Github.com / Github Enterprise / Gitlab / Bitbucket Server should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
+This util helps generate data needed to mirror the Github.com / Github Enterprise / Gitlab / Bitbucket Server / Bitbucket Cloud organization structure in Snyk.
+This is an opinionated util and will assume every organization in Github.com / Github Enterprise / Gitlab / Bitbucket Server / Bitbucket Cloud should become an organization in Snyk. If this is not what you are looking for, please look at using the [Organizations API](https://snyk.docs.apiary.io/#reference/groups/organizations-in-a-group/create-a-new-organization-in-a-group) directly to create the structure you need.
 
 ## Options
 ```
@@ -60,6 +61,16 @@ This will create the organization data in a file `group-<snyk_group_id>-gitlab-o
  - `snyk-api-import orgs:data --source=bitbucket-server --groupId=<snyk_group_id> --sourceUrl=https://bitbucket-server.custom.com`
 
 This will create the organization data in a file `group-<snyk_group_id>-bitbucket-server-orgs.json`
+
+
+## Bitbucket Cloud
+**Note that the URL for Bitbucket Cloud is https://bitbucket.org/**
+1. set the Bitbucket Cloud Username and Password as an environment variables: `export BITBUCKET_CLOUD_USERNAME=your_bitbucket_cloud_username` and `export BITBUCKET_CLOUD_PASSWORD=your_bitbucket_cloud_password`
+2. Run the command to generate organization data:
+ - `snyk-api-import orgs:data --source=bitbucket-cloud --groupId=<snyk_group_id>`
+
+This will create the organization data in a file `group-<snyk_group_id>-bitbucket-cloud-orgs.json`
+
 
 # Creating Organizations in Snyk
 Use the generated data file to help create the organizations via API or use the provided util.

--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -39,7 +39,7 @@ export const builder = {
     default: SupportedIntegrationTypesImportOrgData.GITHUB,
     choices: [...Object.values(SupportedIntegrationTypesImportOrgData)],
     desc:
-      'The source of the targets to be imported e.g. Github, Github Enterprise, Gitlab, Bitbucket Server',
+      'The source of the targets to be imported e.g. Github, Github Enterprise, Gitlab, Bitbucket Server, Bitbucket Cloud',
   },
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,6 +88,7 @@ export enum SupportedIntegrationTypesImportOrgData {
   GHE = 'github-enterprise',
   GITLAB = 'gitlab',
   BITBUCKET_SERVER = 'bitbucket-server',
+  BITBUCKET_CLOUD = 'bitbucket-cloud',
 }
 
 // used to generate imported targets that exist in Snyk

--- a/src/scripts/generate-org-data.ts
+++ b/src/scripts/generate-org-data.ts
@@ -10,6 +10,10 @@ import {
   gitlabGroupIsEmpty,
 } from '../lib/source-handlers/gitlab';
 import {
+  bitbucketCloudWorkspaceIsEmpty,
+  listBitbucketCloudWorkspaces,
+} from '../lib/source-handlers/bitbucket-cloud/';
+import {
   bitbucketServerProjectIsEmpty,
   listBitbucketServerProjects,
 } from '../lib/source-handlers/bitbucket-server/';
@@ -24,6 +28,7 @@ const sourceGenerators = {
   [SupportedIntegrationTypesImportOrgData.GITHUB]: githubOrganizations,
   [SupportedIntegrationTypesImportOrgData.GHE]: githubEnterpriseOrganizations,
   [SupportedIntegrationTypesImportOrgData.BITBUCKET_SERVER]: listBitbucketServerProjects,
+  [SupportedIntegrationTypesImportOrgData.BITBUCKET_CLOUD]: listBitbucketCloudWorkspaces,
 };
 
 const sourceNotEmpty = {
@@ -31,6 +36,7 @@ const sourceNotEmpty = {
   [SupportedIntegrationTypesImportOrgData.GHE]: githubOrganizationIsEmpty,
   [SupportedIntegrationTypesImportOrgData.GITLAB]: gitlabGroupIsEmpty,
   [SupportedIntegrationTypesImportOrgData.BITBUCKET_SERVER]: bitbucketServerProjectIsEmpty,
+  [SupportedIntegrationTypesImportOrgData.BITBUCKET_CLOUD]: bitbucketCloudWorkspaceIsEmpty
 };
 
 export const entityName: {
@@ -40,6 +46,7 @@ export const entityName: {
   'github-enterprise': 'organization',
   gitlab: 'group',
   'bitbucket-server': 'project',
+  'bitbucket-cloud': 'workspace',
 };
 
 const exportFileName: {
@@ -49,6 +56,7 @@ const exportFileName: {
   'github-enterprise': 'github-enterprise',
   gitlab: 'gitlab',
   'bitbucket-server': 'bitbucket-server',
+  'bitbucket-cloud': 'bitbucket-cloud',
 };
 
 export async function generateOrgImportDataFile(

--- a/src/scripts/generate-targets-data.ts
+++ b/src/scripts/generate-targets-data.ts
@@ -17,6 +17,7 @@ import {
   listBitbucketServerRepos,
   BitbucketServerRepoData,
   listBitbucketCloudRepos,
+  BitbucketCloudRepoData,
 } from '../lib';
 
 const debug = debugLib('snyk:generate-targets-data');
@@ -92,10 +93,7 @@ export async function generateTargetsImportDataFile(
     try {
       validateRequiredOrgData(name, integrations, orgId);
       const entities: Array<
-        | GithubRepoData
-        | GitlabRepoData
-        | AzureRepoData
-        | BitbucketServerRepoData
+        GithubRepoData | GitlabRepoData | AzureRepoData | BitbucketServerRepoData | BitbucketCloudRepoData
       > = await sourceGenerators[source](topLevelEntity.name, sourceUrl!);
       entities.forEach((entity) => {
         targetsData.push({

--- a/test/system/__snapshots__/orgs:data.test.ts.snap
+++ b/test/system/__snapshots__/orgs:data.test.ts.snap
@@ -26,9 +26,10 @@ Options:
   --skipEmptyOrgs      Skip any organizations that do not any targets. (e.g.
                        Github Organization does not have any repos)
   --source             The source of the targets to be imported e.g. Github,
-                       Github Enterprise, Gitlab, Bitbucket Server
+                       Github Enterprise, Gitlab, Bitbucket Server, Bitbucket
+                       Cloud
                    [required] [choices: "github", "github-enterprise", "gitlab",
-                                         "bitbucket-server"] [default: "github"]
+                      "bitbucket-server", "bitbucket-cloud"] [default: "github"]
 
 Missing required argument: groupId
 ]
@@ -53,7 +54,8 @@ Options:
   --skipEmptyOrgs      Skip any organizations that do not any targets. (e.g.
                        Github Organization does not have any repos)
   --source             The source of the targets to be imported e.g. Github,
-                       Github Enterprise, Gitlab, Bitbucket Server
+                       Github Enterprise, Gitlab, Bitbucket Server, Bitbucket
+                       Cloud
                    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\",
-                                         \\"bitbucket-server\\"] [default: \\"github\\"]"
+                      \\"bitbucket-server\\", \\"bitbucket-cloud\\"] [default: \\"github\\"]"
 `;


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

adds the orgs:data command for bitbucket cloud
