### PR TITLE
fix: remove extraneous imported target logging

### DIFF
--- a/src/lib/api/import/index.ts
+++ b/src/lib/api/import/index.ts
@@ -87,18 +87,6 @@ export async function importTarget(
   } catch (error) {
     const errorBody = error.data || error;
     const errorMessage = errorBody.message;
-    await logFailedImports(
-      orgId,
-      integrationId,
-      target,
-      {
-        errorMessage: errorBody.message,
-        name: error.name,
-        code: errorBody.code,
-        requestId: error.requestId,
-      },
-      loggingPath,
-    );
     const err: {
       message?: string | undefined;
       innerError?: string;


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

The failed targets are logged twice today as we already do this here: https://github.com/snyk-tech-services/snyk-api-import/blob/57b9d225b8133b9fd6934c3b9562ef7ea00c5cc6/src/lib/api/import/index.ts#L148