### PR TITLE
fix: sanitise url for getrepos

### DIFF
--- a/src/lib/request-with-rate-limit.ts
+++ b/src/lib/request-with-rate-limit.ts
@@ -23,6 +23,7 @@ export async function limiterWithRateLimitRetries<ResponseType>(
   };
   const maxRetries = 7;
   let attempt = 0;
+  const encodedUrl = encodeURI(url);
   limiter.on('failed', async (error, jobInfo) => {
     const id = jobInfo.options.id;
     debug(`Job ${id} failed: ${error}`);
@@ -34,7 +35,7 @@ export async function limiterWithRateLimitRetries<ResponseType>(
   });
   while (attempt < maxRetries) {
     data = (await limiter.schedule(() =>
-      needle(verb, url, { headers: headers }),
+      needle(verb, encodedUrl, { headers: headers }),
     )) as {
       statusCode: number;
       body: ResponseType;

--- a/test/lib/request-with-rate-limit.test.ts
+++ b/test/lib/request-with-rate-limit.test.ts
@@ -6,7 +6,14 @@ beforeEach(() => {
   return nock('https://testUrlOkResponse')
     .persist()
     .get(/.*/)
-    .reply(200, ['test 1', 'test 2']);
+    .reply(200, (uri) => {
+      switch (uri) {
+        case '/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B%20%F0%9F%9B%A0':
+          return ['test 3'];
+        case '/':
+          return ['test1', 'test2'];
+      }
+    });
 });
 
 beforeEach(() => {
@@ -30,6 +37,17 @@ describe('Testing requestWithRateLimitRetries', () => {
       600,
     );
     expect(data.body).toHaveLength(2);
+  }, 20000);
+  test('Test requestWithRateLimitRetries with unescape charaters iterates returns an array when response code is 200', async () => {
+    const url = 'https://testUrlOkResponse/?x=шеллы 🛠';
+    const data = await limiterWithRateLimitRetries(
+      'get',
+      url,
+      {},
+      limiter,
+      600,
+    );
+    expect(data.body).toHaveLength(1);
   }, 20000);
   test('Test requestWithRateLimitRetries iterates 7 times when response code is 429', async () => {
     const data = await limiterWithRateLimitRetries(


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

### What this does

Encode the url before sending the requests. This will allow repos name with icons, Chinese characters....

