### PR TITLE
fix: filter projects to origin if a single one provided

### DIFF
--- a/src/cmds/list:imported.ts
+++ b/src/cmds/list:imported.ts
@@ -22,7 +22,7 @@ export const builder = {
       'Public id of the organization in Snyk (available in organization settings)',
   },
   integrationType: {
-    required: true,
+    required: true, // TODO: allow to not set any type to return all
     default: [...Object.values(SupportedIntegrationTypesToListSnykTargets)],
     choices: [...Object.values(SupportedIntegrationTypesToListSnykTargets)],
     desc:

--- a/src/lib/api/org/index.ts
+++ b/src/lib/api/org/index.ts
@@ -4,6 +4,7 @@ import * as debugLib from 'debug';
 import { getApiToken } from '../../get-api-token';
 import { getSnykHost } from '../../get-snyk-host';
 import { SnykProject } from '../../types';
+import { StringNullableChain } from 'lodash';
 
 const debug = debugLib('snyk:api-group');
 
@@ -141,9 +142,17 @@ interface ProjectsResponse {
   projects: SnykProject[];
 }
 
+interface ProjectsFilters {
+  name?: StringNullableChain; // If supplied, only projects that have a name that starts with this value will be returned
+  origin?: string; //If supplied, only projects that exactly match this origin will be returned
+  type?: string; //If supplied, only projects that exactly match this type will be returned
+  isMonitored?: boolean; // If set to true, only include projects which are monitored, if set to false, only include projects which are not monitored
+}
+
 export async function listProjects(
   requestManager: requestsManager,
   orgId: string,
+  filters?: ProjectsFilters,
 ): Promise<ProjectsResponse> {
   getApiToken();
   getSnykHost();
@@ -156,7 +165,6 @@ export async function listProjects(
     );
   }
 
-  const filters = {};
   try {
     const res = await requestManager.request({
       verb: 'post',

--- a/src/scripts/generate-imported-targets-from-snyk.ts
+++ b/src/scripts/generate-imported-targets-from-snyk.ts
@@ -116,13 +116,16 @@ export async function generateSnykImportedTargets(
     ? await getAllOrgs(requestManager, groupId)
     : [{ id: orgId! }];
   const failedOrgs: SnykOrg[] = [];
+  const projectFilters = {
+    origin: integrationTypes.length > 1 ? undefined : integrationTypes[0]
+  }
   await pMap(
     groupOrgs,
     async (org: SnykOrg) => {
       const { id: orgId, name, slug } = org;
       try {
         const [resProjects, resIntegrations] = await Promise.all([
-          listProjects(requestManager, orgId),
+          listProjects(requestManager, orgId, projectFilters),
           listIntegrations(requestManager, orgId),
         ]);
         const { projects } = resProjects;

--- a/test/lib/generate-target-ids.test.ts
+++ b/test/lib/generate-target-ids.test.ts
@@ -1,4 +1,4 @@
-import { generateTargetId } from '../src/generate-target-id';
+import { generateTargetId } from '../../src/generate-target-id';
 
 describe('generateTargetId', () => {
   it('correctly generates Gitlab target ID', () => {

--- a/test/scripts/generate-imported-targets-from-snyk.test.ts
+++ b/test/scripts/generate-imported-targets-from-snyk.test.ts
@@ -31,7 +31,7 @@ describe('Generate imported targets based on Snyk data', () => {
     process.env = { ...OLD_ENV };
   });
 
-  it('succeeds to generate targets for Group for Github', async () => {
+  it('succeeds to generate targets for Group for Github & GHE', async () => {
     const logFiles = generateLogsPaths(__dirname, ORG_ID);
     logs = Object.values(logFiles);
     const {
@@ -39,94 +39,6 @@ describe('Generate imported targets based on Snyk data', () => {
       failedOrgs,
       fileName,
     } = await generateSnykImportedTargets({ groupId: GROUP_ID }, [
-      SupportedIntegrationTypesToListSnykTargets.GITHUB,
-    ]);
-    expect(failedOrgs).toEqual([]);
-    expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
-    expect(targets[0]).toMatchObject({
-      integrationId: expect.any(String),
-      orgId: expect.any(String),
-      target: {
-        branch: expect.any(String),
-        name: expect.any(String),
-        owner: expect.any(String),
-      },
-    });
-    // give file a little time to be finished to be written
-    await new Promise((r) => setTimeout(r, 20000));
-    const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
-    expect(importedTargetsLog).toMatch(targets[0].target.owner as string);
-    expect(importedTargetsLog).toMatch(targets[0].orgId);
-    expect(importedTargetsLog).toMatch(targets[0].integrationId);
-  }, 240000);
-
-  it('succeeds to generate targets for Org + Github', async () => {
-    const logFiles = generateLogsPaths(__dirname, ORG_ID);
-    logs = Object.values(logFiles);
-    const {
-      targets,
-      failedOrgs,
-      fileName,
-    } = await generateSnykImportedTargets({ orgId: ORG_ID }, [
-      SupportedIntegrationTypesToListSnykTargets.GITHUB,
-    ]);
-    expect(failedOrgs).toEqual([]);
-    expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
-    expect(targets[0]).toMatchObject({
-      integrationId: expect.any(String),
-      orgId: expect.any(String),
-      target: {
-        branch: expect.any(String),
-        name: expect.any(String),
-        owner: expect.any(String),
-      },
-    });
-    // give file a little time to be finished to be written
-    await new Promise((r) => setTimeout(r, 20000));
-    const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
-    expect(importedTargetsLog).toMatch(targets[0].target.owner as string);
-    expect(importedTargetsLog).toMatch(targets[0].orgId);
-    expect(importedTargetsLog).toMatch(targets[0].integrationId);
-  }, 240000);
-
-  it('succeeds to generate targets for Group for Github & Github Enterprise', async () => {
-    const logFiles = generateLogsPaths(__dirname, ORG_ID);
-    logs = Object.values(logFiles);
-    const {
-      targets,
-      failedOrgs,
-      fileName,
-    } = await generateSnykImportedTargets({ groupId: GROUP_ID }, [
-      SupportedIntegrationTypesToListSnykTargets.GITHUB,
-      SupportedIntegrationTypesToListSnykTargets.GHE,
-    ]);
-    expect(failedOrgs).toEqual([]);
-    expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
-    expect(targets[0]).toMatchObject({
-      integrationId: expect.any(String),
-      orgId: expect.any(String),
-      target: {
-        branch: expect.any(String),
-        name: expect.any(String),
-        owner: expect.any(String),
-      },
-    });
-    // give file a little time to be finished to be written
-    await new Promise((r) => setTimeout(r, 20000));
-    const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
-    expect(importedTargetsLog).toMatch(targets[0].target.owner as string);
-    expect(importedTargetsLog).toMatch(targets[0].orgId);
-    expect(importedTargetsLog).toMatch(targets[0].integrationId);
-  }, 240000);
-
-  it('succeeds to generate targets for Org for Github & Github Enterprise', async () => {
-    const logFiles = generateLogsPaths(__dirname, ORG_ID);
-    logs = Object.values(logFiles);
-    const {
-      targets,
-      failedOrgs,
-      fileName,
-    } = await generateSnykImportedTargets({ orgId: ORG_ID }, [
       SupportedIntegrationTypesToListSnykTargets.GITHUB,
       SupportedIntegrationTypesToListSnykTargets.GHE,
     ]);
@@ -179,35 +91,6 @@ describe('Generate imported targets based on Snyk data', () => {
     expect(importedTargetsLog).toMatch(targets[0].integrationId);
   }, 240000);
 
-  it('succeeds to generate targets for Group for Azure', async () => {
-    const logFiles = generateLogsPaths(__dirname, ORG_ID);
-    logs = Object.values(logFiles);
-    const {
-      targets,
-      failedOrgs,
-      fileName,
-    } = await generateSnykImportedTargets({ groupId: GROUP_ID }, [
-      SupportedIntegrationTypesToListSnykTargets.AZURE_REPOS,
-    ]);
-    expect(failedOrgs).toEqual([]);
-    expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
-    expect(targets[0]).toMatchObject({
-      integrationId: expect.any(String),
-      orgId: expect.any(String),
-      target: {
-        branch: expect.any(String),
-        name: expect.any(String),
-        owner: expect.any(String),
-      },
-    });
-    // give file a little time to be finished to be written
-    await new Promise((r) => setTimeout(r, 20000));
-    const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
-    expect(importedTargetsLog).toMatch(targets[0].target.owner as string);
-    expect(importedTargetsLog).toMatch(targets[0].orgId);
-    expect(importedTargetsLog).toMatch(targets[0].integrationId);
-  }, 240000);
-
   it('succeeds to generate targets for Org + Azure', async () => {
     const logFiles = generateLogsPaths(__dirname, ORG_ID);
     logs = Object.values(logFiles);
@@ -233,34 +116,6 @@ describe('Generate imported targets based on Snyk data', () => {
     await new Promise((r) => setTimeout(r, 20000));
     const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
     expect(importedTargetsLog).toMatch(targets[0].target.owner as string);
-    expect(importedTargetsLog).toMatch(targets[0].orgId);
-    expect(importedTargetsLog).toMatch(targets[0].integrationId);
-  }, 240000);
-
-  it('succeeds to generate targets for Group for Bitbucket server', async () => {
-    const logFiles = generateLogsPaths(__dirname, ORG_ID);
-    logs = Object.values(logFiles);
-    const {
-      targets,
-      failedOrgs,
-      fileName,
-    } = await generateSnykImportedTargets({ groupId: GROUP_ID }, [
-      SupportedIntegrationTypesToListSnykTargets.BITBUCKET_SERVER,
-    ]);
-    expect(failedOrgs).toEqual([]);
-    expect(fileName).toEqual(path.resolve(__dirname, IMPORT_LOG_NAME));
-    expect(targets[0]).toMatchObject({
-      integrationId: expect.any(String),
-      orgId: expect.any(String),
-      target: {
-        projectKey: expect.any(String),
-        repoSlug: expect.any(String),
-      },
-    });
-    // give file a little time to be finished to be written
-    await new Promise((r) => setTimeout(r, 20000));
-    const importedTargetsLog = fs.readFileSync(logFiles.importLogPath, 'utf8');
-    expect(importedTargetsLog).toMatch(targets[0].target.projectKey as string);
     expect(importedTargetsLog).toMatch(targets[0].orgId);
     expect(importedTargetsLog).toMatch(targets[0].integrationId);
   }, 240000);


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
- reduce the # of tests as they cover much of the same area
- combine some of the GHE tests
- move the target id test into test/lib
- filter projects by origin if a single origin aka type is provided to the `list:imported` command, list all if more than one is provided
