### PR TITLE
fix: exit code 1 if `orgs:data` errors

### DIFF
--- a/src/cmds/orgs:data.ts
+++ b/src/cmds/orgs:data.ts
@@ -1,4 +1,5 @@
 import * as debugLib from 'debug';
+import * as yargs from 'yargs';
 const debug = debugLib('snyk:orgs-data-script');
 
 import { getLoggingPath } from '../lib/get-logging-path';
@@ -75,9 +76,9 @@ export async function handler(argv: {
 
     console.log(orgsMessage);
   } catch (e) {
+    const errorMessage = `ERROR! Failed to generate data. Try running with \`DEBUG=snyk* <command> for more info\`.\nERROR: ${e.message}`;
     debug('Failed to generate data.\n' + e);
-    console.error(
-      `ERROR! Failed to generate data. Try running with \`DEBUG=snyk* <command> for more info\`.\nERROR: ${e}`,
-    );
+    console.error(errorMessage);
+    yargs.exit(1, new Error(errorMessage));
   }
 }

--- a/test/system/orgs:data/errors.test.ts
+++ b/test/system/orgs:data/errors.test.ts
@@ -17,4 +17,25 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
       done();
     });
   });
+  it('Shows error when token is invalid', (done) => {
+    const groupId = 'hello';
+    exec(
+      `node ${main} orgs:data --source=github --groupId=${groupId}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          GITHUB_TOKEN: 'invalid',
+          SNYK_LOG_PATH: __dirname,
+        },
+      },
+      (err, stdout, stderr) => {
+        expect(err!.message).toMatch('ERROR: Bad credentials');
+        expect(stdout).toEqual('');
+        expect(stderr).toMatch('ERROR: Bad credentials');
+      },
+    ).on('exit', (code) => {
+      expect(code).toEqual(1);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Manually set exit code 1 is `orgs:data` command errors.