### PR TITLE
docs: set signed certificate path for API calls to SCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn global add snyk-api-import
 
 # Usage
 By default the `import` command will run if no command specified.
-- `import` - kick off a an API powered import of repos/targets into existing Snyk orgs defined in [import configuration file](./docs/import.md).
+- `import` - kick off a an API powered import of repos/targets into existing Snyk orgs defined in [import configuration file](./docs/import.md). 100% support available for all project types supported via [Import API](https://snyk.docs.apiary.io/#reference/integrations/import-projects/import).
 - `help` - show help & all available commands and their options
 - `orgs:data` - util generate data required to create Orgs via API.
 - `orgs:create` - util to create the Orgs in Snyk based on data file generated with `orgs:data` command.
@@ -81,10 +81,28 @@ The logs can be explored using [Bunyan CLI](http://trentm.com/node-bunyan/bunyan
   </ul>
 </details>
 <details>
+<summary><code>ERROR: HttpError: request to https://github.private.com failed, reason: self signed certificate in certificate chain</code></summary>
+<br/>
+  <p>If your Github / Gitlab / Bitbucket / Azure is using a self signed certificate, you can configure snyk-api-import to use this certificate when calling the HTTPS APIs.</p>
+  <code>export NODE_EXTRA_CA_CERTS=./path-to-ca</code>
+  <p>Some of these resources may help you bump the <b>ulimit</b>:</p>
+  <ul>
+    <li><a href="https://nodejs.org/api/cli.html#node_extra_ca_certsfile">nodejs.org</a></li>
+  </ul>
+</details>
+<details>
 <summary>Does this work with brokered integrations?</summary>
 <br/>
   <p>
     Yes. because we reuse the existing integration with your SCM (git) repository to perform the imports, the brokered connection will be used when configured.
   </p>
 </details>
+<details>
+<summary>What is supported for import command?</summary>
+<br/>
+  <p>
+    snyk-api-import supports 100% of the same integration types and project sources as the <a href="https://snyk.docs.apiary.io/#reference/integrations/import-projects/import">Import API documentation</a>. If an example is not in the docs for your use case please see the API documentation
+  </p>
+</details>
+
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

- Document how to set signed certificate path for API calls to SCM
- Document that 100% of API import sources are supported for `import`

