### PR TITLE
feat: exit code 1 if all orgs fail to create

### DIFF
--- a/src/cmds/orgs:create.ts
+++ b/src/cmds/orgs:create.ts
@@ -1,4 +1,5 @@
 import * as debugLib from 'debug';
+import * as yargs from 'yargs';
 const debug = debugLib('snyk:orgs-create-script');
 
 import { getLoggingPath } from '../lib';
@@ -46,9 +47,9 @@ export async function handler(argv: {
 
     console.log(orgsMessage);
   } catch (e) {
+    const errorMessage = `ERROR! Failed to create organizations.\nTry running with \`DEBUG=snyk* <command> for more info\`.\nERROR: ${e.message}`;
     debug('Failed to create organizations.\n' + e);
-    console.error(
-      `${e}.\nTry running with \`DEBUG=snyk* <command> for more info\`.\nERROR: ${e}`,
-    );
+    console.error(errorMessage);
+    setTimeout(() => yargs.exit(1, new Error(errorMessage)), 3000);
   }
 }

--- a/src/loggers/log-failed-org.ts
+++ b/src/loggers/log-failed-org.ts
@@ -22,7 +22,6 @@ export async function logFailedOrg(
       },
     ],
   });
-
   try {
     log.error({ origName, groupId, errorMessage }, 'Failed to create org');
   } catch (e) {

--- a/src/scripts/create-orgs.ts
+++ b/src/scripts/create-orgs.ts
@@ -59,7 +59,7 @@ async function createNewOrgs(
         origName: name,
         sourceOrgId,
       });
-      logCreatedOrg(groupId, name, org, integrations, loggingPath);
+      await logCreatedOrg(groupId, name, org, integrations, loggingPath);
     } catch (e) {
       failed.push({ groupId, name, sourceOrgId });
       const errorMessage = e.data ? e.data.message : e.message;

--- a/test/lib/org.test.ts
+++ b/test/lib/org.test.ts
@@ -16,7 +16,7 @@ describe('Org notification settings', () => {
   });
   afterAll(async () => {
     process.env = { ...OLD_ENV };
-  });
+  }, 1000);
   it('Can change the notification settings for org', async () => {
     const res = await setNotificationPreferences(
       requestManager,
@@ -68,7 +68,7 @@ describe('listProjects', () => {
   });
   afterAll(async () => {
     process.env = { ...OLD_ENV };
-  });
+  }, 1000);
   it('Lists projects in a given Org', async () => {
     const res = await listProjects(requestManager, ORG_ID);
     expect(res).toMatchObject({
@@ -82,5 +82,5 @@ describe('listProjects', () => {
       name: expect.any(String),
       branch: expect.any(String),
     });
-  });
+  }, 5000);
 });

--- a/test/system/orgs:create.test.ts
+++ b/test/system/orgs:create.test.ts
@@ -59,26 +59,25 @@ Options:
         },
       },
       (err, stdout, stderr) => {
-        if (err) {
-          throw err;
-        }
         expect(stderr).toMatch(
           'All requested organizations failed to be created. Review the errors in',
         );
-        expect(err).toBeNull();
-        expect(stdout).toEqual('');
-        const file = fs.readFileSync(
-          path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`),
-          'utf8',
+        expect(err!.message).toMatch(
+          'All requested organizations failed to be created. Review the errors in',
         );
-        expect(file).toContain('Failed to create org');
-        deleteFiles([path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`)]);
+        expect(stdout).toEqual('');
       },
     ).on('exit', (code) => {
-      expect(code).toEqual(0);
+      expect(code).toEqual(1);
+      const file = fs.readFileSync(
+        path.join(logPath, `abc.${FAILED_ORG_LOG_NAME}`),
+        'utf8',
+      );
+      expect(file).toContain('Failed to create org');
+      deleteFiles([path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`)]);
       done();
     });
-  }, 20000);
+  }, 40000);
 
   it('Fails to create an org as expected for non existing group ID `abc` file not in the same location as logs', (done) => {
     const pathToBadJson = path.resolve(
@@ -99,13 +98,12 @@ Options:
         },
       },
       (err, stdout, stderr) => {
-        if (err) {
-          throw err;
-        }
         expect(stderr).toMatch(
           'All requested organizations failed to be created. Review the errors in',
         );
-        expect(err).toBeNull();
+        expect(err!.message).toMatch(
+          'All requested organizations failed to be created. Review the errors in',
+        );
         expect(stdout).toEqual('');
         const file = fs.readFileSync(
           path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`),
@@ -115,10 +113,10 @@ Options:
         deleteFiles([path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`)]);
       },
     ).on('exit', (code) => {
-      expect(code).toEqual(0);
+      expect(code).toEqual(1);
       done();
     });
-  }, 20000);
+  }, 40000);
 
   it('Fails to create orgs in --noDuplicateNames mode when org already exists ', (done) => {
     const pathToBadJson = path.resolve(
@@ -139,13 +137,12 @@ Options:
         },
       },
       (err, stdout, stderr) => {
-        if (err) {
-          throw err;
-        }
         expect(stderr).toMatch(
           'All requested organizations failed to be created. Review the errors in',
         );
-        expect(err).toBeNull();
+        expect(err!.message).toMatch(
+          'All requested organizations failed to be created. Review the errors in',
+        );
         expect(stdout).toEqual('');
         const file = fs.readFileSync(
           path.resolve(logPath, `${GROUP_ID}.${FAILED_ORG_LOG_NAME}`),
@@ -157,8 +154,8 @@ Options:
         ]);
       },
     ).on('exit', (code) => {
-      expect(code).toEqual(0);
+      expect(code).toEqual(1);
       done();
     });
-  }, 20000);
+  }, 40000);
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Ensure exit code 1 when all orgs fail to create