### PR TITLE
feat: filter gitlab projects that are shared

### DIFF
--- a/src/lib/source-handlers/gitlab/list-repos.ts
+++ b/src/lib/source-handlers/gitlab/list-repos.ts
@@ -29,7 +29,10 @@ export async function fetchGitlabReposForPage(
     hasNextPage = true;
     repoData.push(
       ...projects
-        .filter((project: any) => !project.archived)
+        .filter(
+          (project: any) =>
+            !project.archived && project.shared_with_groups?.length == 0,
+        )
         .map((project: any) => ({
           fork: !!project.forked_from_project,
           name: project.path_with_namespace,

--- a/test/lib/source-handlers/gitlab/list-repos.test.ts
+++ b/test/lib/source-handlers/gitlab/list-repos.test.ts
@@ -22,5 +22,8 @@ describe('listGitlabRepos', () => {
       branch: expect.any(String),
       fork: expect.any(Boolean),
     });
+    for (let i = 0; i < repos.length; i ++){
+      expect(repos[i].name).not.toContain("shared-with-group");
+    }
   });
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Filters Gitlab projects that are shared with other groups

### More information

- [Slack Thread](https://snyk.slack.com/archives/C010RJA3205/p1651153164796579)
- [Jira Ticket](https://snyksec.atlassian.net/browse/TECHSERV-1866)