### PR TITLE
fix: filter out Gitlab projects without branch

### DIFF
--- a/src/lib/source-handlers/gitlab/list-repos.ts
+++ b/src/lib/source-handlers/gitlab/list-repos.ts
@@ -29,11 +29,22 @@ export async function fetchGitlabReposForPage(
     hasNextPage = true;
     repoData.push(
       ...projects
-        .filter(
-          (project: any) =>
-            !project.archived && project.shared_with_groups?.length == 0,
-        )
-        .map((project: any) => ({
+        .filter((project) => {
+          const {
+            archived,
+            shared_with_groups,
+            default_branch,
+          } = project as types.Types.ProjectExtendedSchema;
+          if (
+            archived ||
+            !default_branch ||
+            (shared_with_groups && shared_with_groups.length > 0)
+          ) {
+            return false;
+          }
+          return true;
+        })
+        .map((project) => ({
           fork: !!project.forked_from_project,
           name: project.path_with_namespace,
           id: project.id,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Filter out Gitlab projects that do not yet have a branch (aka the repo is empty)
