### PR TITLE
feat: refactor orgs data

### DIFF
--- a/test/system/import:data.test.ts
+++ b/test/system/import:data.test.ts
@@ -57,7 +57,7 @@ Options:
     });
   });
 
-  it('Generates repo data as expected for Gitlab', (done) => {
+  it.only('Generates repo data as expected for Gitlab', (done) => {
     const orgDataFile = 'test/system/fixtures/org-data/orgs.json';
     exec(
       `node ${main} import:data --source=gitlab --integrationType=gitlab --sourceUrl=${process.env.TEST_GITLAB_BASE_URL} --orgsData=${orgDataFile}`,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Refactor Org:data command. Move the code to a function returning an object to be used in a mirror script later.

