### PR TITLE
fix: always send danitized target

### DIFF
--- a/src/lib/api/import/index.ts
+++ b/src/lib/api/import/index.ts
@@ -32,7 +32,6 @@ export async function importTarget(
   integrationId: string;
 }> {
   const logPath = loggingPath || getLoggingPath();
-  const sanitizeTarget = Boolean(process.env.SANITIZE_IMPORT_TARGET);
   getApiToken();
   debug('Importing:', JSON.stringify({ orgId, integrationId, target }));
 
@@ -44,7 +43,7 @@ export async function importTarget(
   }
   try {
     const body = {
-      target: sanitizeTarget ? _.pick(target, ...targetPropsWithId) : target,
+      target: _.pick(target, ...targetPropsWithId),
       files,
       exclusionGlobs,
     };

--- a/test/lib/import-projects.test.ts
+++ b/test/lib/import-projects.test.ts
@@ -140,9 +140,7 @@ describe('importTarget()', () => {
   afterAll(async () => {
     process.env = { ...OLD_ENV };
   });
-  it('SANITIZE target if process.env.SANITIZE_IMPORT_TARGET is set', async () => {
-    process.env.SANITIZE_IMPORT_TARGET = 'yes';
-
+  it('Target is always sanitized', async () => {
     const target = {
       name: 'composer-with-vulns',
       owner: 'api-import-circle-test',
@@ -162,35 +160,6 @@ describe('importTarget()', () => {
           branch: 'master',
           name: 'composer-with-vulns',
           owner: 'api-import-circle-test',
-        },
-      },
-    );
-  });
-
-  it('send target as if process.env.SANITIZE_IMPORT_TARGET is not set', async () => {
-    delete process.env.SANITIZE_IMPORT_TARGET;
-    const target = {
-      name: 'composer-with-vulns',
-      owner: 'api-import-circle-test',
-      branch: 'master',
-      fork: true,
-      random: 'yay'
-    };
-    await importTarget(requestManager, 'ORG_ID', 'INTEGRATION_ID', target);
-    expect(requestWithRateLimitHandlingStub).toHaveBeenCalled();
-    expect(requestWithRateLimitHandlingStub).lastCalledWith(
-      expect.any(Object),
-      '/org/ORG_ID/integrations/INTEGRATION_ID/import',
-      'post',
-      {
-        exclusionGlobs: undefined,
-        files: undefined,
-        target: {
-          branch: 'master',
-          name: 'composer-with-vulns',
-          owner: 'api-import-circle-test',
-          fork: true,
-          random: 'yay'
         },
       },
     );


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Target sent to Snyk APIs is always sanitized by default.
