### PR TITLE
feat: assume enterprise might include Github Enterprise Cloud

### DIFF
--- a/docs/import-data.md
+++ b/docs/import-data.md
@@ -13,8 +13,8 @@ This is a util that can help generate the import json data needed by the import 
 
 
 # `import:data`
-## Github.com / Github Enterprise
-1. set the [Github.com personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
+## Github.com / Github Enterprise Server / Github Enterprise Cloud
+1. set the [Github.com / Github Enterprise Server / Github Enterprise Cloud token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as an environment variable: `export GITHUB_TOKEN=your_personal_access_token`
 2. You will need to have the organizations data in json as an input to this command to help map Snyk organization IDs and Integration Ids that must be used during import against individual targets to be imported. The following format is required:
   ```
   {
@@ -39,7 +39,8 @@ This is a util that can help generate the import json data needed by the import 
 
 3. Run the command to generate import data:
  - **Github.com:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github --integrationType=github`
- - **Github Enterprise:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise --integrationType=github-enterprise --sourceUrl=https://ghe.custom.com`
+ - **Github Enterprise Server:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise --integrationType=github-enterprise --sourceUrl=https://ghe.custom.com`
+ - **Github Enterprise Cloud:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise --integrationType=github-enterprise`
 
 4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
 

--- a/src/lib/source-handlers/github/list-organizations.ts
+++ b/src/lib/source-handlers/github/list-organizations.ts
@@ -86,8 +86,8 @@ export async function githubEnterpriseOrganizations(
   sourceUrl?: string,
 ): Promise<SnykOrgData[]> {
   if (!sourceUrl) {
-    throw new Error(
-      'Please provide required `sourceUrl` for Github Enterprise source',
+   console.warn(
+      'No `sourceUrl` provided for Github Enterprise source, defaulting to https://api.github.com',
     );
   }
   const ghOrgs: GithubOrgData[] = await listGithubOrgs(sourceUrl);

--- a/src/scripts/generate-targets-data.ts
+++ b/src/scripts/generate-targets-data.ts
@@ -27,8 +27,8 @@ async function githubEnterpriseRepos(
   sourceUrl?: string,
 ): Promise<GithubRepoData[]> {
   if (!sourceUrl) {
-    throw new Error(
-      'Please provide required `sourceUrl` for Github Enterprise source',
+    console.warn(
+      'No `sourceUrl` provided for Github Enterprise source, defaulting to https://api.github.com',
     );
   }
   const ghRepos: GithubRepoData[] = await listGithubRepos(orgName, sourceUrl);

--- a/test/scripts/generate-org-data.test.ts
+++ b/test/scripts/generate-org-data.test.ts
@@ -75,7 +75,7 @@ describe('generateOrgImportDataFile Github script', () => {
     });
   });
 
-  it('throws an error when Github Enterprise Orgs requested without sourceUrl', async () => {
+  it('throws an error when Github Enterprise Server Orgs requested without sourceUrl', async () => {
     process.env.GITHUB_TOKEN = process.env.GHE_TOKEN;
     const groupId = 'groupIdExample';
 
@@ -85,7 +85,7 @@ describe('generateOrgImportDataFile Github script', () => {
         groupId,
       ),
     ).rejects.toThrow(
-      'Please provide required `sourceUrl` for Github Enterprise source',
+      'Bad credentials',
     );
   });
   it('generate Github Enterprise Orgs data', async () => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Make using Github Enterprise Cloud more intuitive by falling back to github.com for Cloud enterprise if no custom url is provided instead of throwing an error

### More information

- https://github.com/snyk-tech-services/snyk-api-import/issues/314
