### PR TITLE
feat: use api v3 get all projects endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "p-map": "4.0.0",
     "parse-link-header": "2.0.0",
     "sleep-promise": "8.0.1",
-    "snyk-request-manager": "1.6.0",
+    "snyk-request-manager": "1.7.1",
     "source-map-support": "^0.5.16",
     "split": "1.0.1",
     "yargs": "16.2.0"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -117,34 +117,14 @@ export interface CommandResult {
 }
 
 export interface SnykProject {
-  name: string;
-  id: string;
-  created: string;
-  origin: string;
-  type: string;
-  readOnly: boolean;
-  testFrequency: string;
-  isMonitored: boolean;
-  totalDependencies: number;
-  issueCountsBySeverity: {
-    low: number;
-    high: number;
-    medium: number;
-    citical: number;
-  };
-  remoteRepoUrl: string; // URL of the repo
-  lastTestedDate: string;
-  browseUrl: string;
-  owner: string | null;
-  importingUser: ImportingUser;
-  tags: unknown[];
-  attributes: {
-    criticality: unknown[];
-    lifecycle: unknown[];
-    environment: unknown[];
-  };
-  branch: string | null;
+  name: string; 
+  id: string; 
+  created: string; 
+  origin: string; 
+  type: string; 
+  branch: string | null;  
 }
+
 
 export interface Org {
   name: string;
@@ -155,4 +135,41 @@ export interface Org {
     name: string;
     id: string;
   };
+}
+
+
+export interface v3ProjectData {
+  attributes: v3ProjectsAttributes;
+  id: string;
+  relationships: v3ProjectsRelationships;
+  type: string
+}
+
+export interface v3ProjectsAttributes {
+  businessCriticality: string;
+  created: string;
+  environment: string;
+  lifecycle: string;
+  name: string;
+  origin: string;
+  status: string;
+  tags: unknown;
+  targetReference: string | null;
+  type: string;
+}
+
+export interface v3ProjectsRelationships {
+  importingUser: v3ProjectsRelashionshipData;
+  org: v3ProjectsRelashionshipData;
+  owner: v3ProjectsRelashionshipData;
+  target: v3ProjectsRelashionshipData;
+}
+
+export interface v3ProjectsRelashionshipData {
+  data: {
+    id: string;
+    type: string;
+  }
+  links: unknown;
+  meta: unknown;
 }

--- a/src/scripts/generate-imported-targets-from-snyk.ts
+++ b/src/scripts/generate-imported-targets-from-snyk.ts
@@ -130,20 +130,21 @@ export async function generateSnykImportedTargets(
         ]);
         const { projects } = resProjects;
         const scmTargets = projects
-          .filter((p) =>
-            integrationTypes.includes(
-              p.origin as SupportedIntegrationTypesToListSnykTargets,
-            ),
-          )
-          .map((p) => {
-            const target = targetGenerators[
-              p.origin as SupportedIntegrationTypesToListSnykTargets
-            ](p);
-            return {
-              target,
-              integrationId: resIntegrations[p.origin],
-            };
-          });
+        .filter((p) =>
+          integrationTypes.includes(
+            p.origin as SupportedIntegrationTypesToListSnykTargets,
+          ),
+        )
+        .map((p) => {
+          const target = targetGenerators[
+            p.origin as SupportedIntegrationTypesToListSnykTargets
+          ](p);
+          return {
+            target,
+            integrationId: resIntegrations[p.origin],
+          };
+        });
+
         const uniqueTargets: Set<string> = new Set();
         const orgTargets: Target[] = [];
         if (!scmTargets.length || scmTargets.length === 0) {

--- a/test/lib/org.test.ts
+++ b/test/lib/org.test.ts
@@ -74,7 +74,6 @@ describe('listProjects', () => {
     expect(res).toMatchObject({
       org: {
         id: ORG_ID,
-        name: expect.any(String),
       },
       projects: expect.any(Array),
     });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Using the API v3 instead of v1 to get the project list.
Tested manually as well as local regression.

