### PR TITLE
fix: drop snyk/scan in favour of commit status checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,6 @@ jobs:
             - checkout
             - run: npm install
             - run: npm test
-            - snyk/scan:
-                fail-on-issues: true
-                monitor-on-build: true
-                severity-threshold: high
-                token-variable: SNYK_TOKEN_PROD
             - run: npx semantic-release
             - slack/status:
                 fail_only: true
@@ -34,11 +29,6 @@ jobs:
             - checkout
             - run: npm install
             - run: npm test
-            - snyk/scan:
-                fail-on-issues: true
-                monitor-on-build: false
-                severity-threshold: high
-                token-variable: SNYK_TOKEN_PROD
             - run: npx tsc
             - run: npm run pkg-binaries-linux
             - run: ./snyk-api-import-linux help


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Drop the `snyk/scan` orb in favour of commit status checks