### PR TITLE
feat: add support for update project branch

### DIFF
--- a/test/lib/__snapshots__/projects.test.ts.snap
+++ b/test/lib/__snapshots__/projects.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpdateProject Update project branch 1`] = `"newDefaultBranch"`;

--- a/test/lib/projects.test.ts
+++ b/test/lib/projects.test.ts
@@ -1,0 +1,58 @@
+import { requestsManager } from 'snyk-request-manager';
+import { updateProject } from '../../src/lib';
+
+jest.unmock('snyk-request-manager');
+jest.requireActual('snyk-request-manager');
+
+describe('UpdateProject', () => {
+    const requestManager = new requestsManager({
+      userAgentPrefix: 'snyk-api-import:tests',
+    });
+    afterAll(async () => {
+      jest.resetAllMocks()
+    }, 1000);
+
+    it('Update project branch', async () => {
+
+        jest.spyOn(requestManager, 'request').mockResolvedValue({ data: {
+            name: "test",
+            id: "af137b96-6966-46c1-826b-2e79ac49bbd9",
+            created: "2018-10-29T09:50:54.014Z",
+            origin: "github",
+            type: "maven",
+            readOnly: false,
+            testFrequency: "daily",
+            totalDependencies: 42,
+            issueCountsBySeverity: {},
+            imageId: "sha256:caf27325b298a6730837023a8a342699c8b7b388b8d",
+            imageTag: "latest",
+            imageBaseImage: "alpine:3",
+            imagePlatform: "linux/arm64",
+            imageCluster: "Production",
+            hostname: null,
+            remoteRepoUrl: "https://github.com/snyk/test.git",
+            lastTestedDate: "2019-02-05T08:54:07.704Z",
+            browseUrl: "https://app.snyk.io/org/4a18d42f-0706-4ad0-b127-24078731fbed/project/af137b96-6966-46c1-826b-2e79ac49bbd9",
+            importingUser: {},
+            isMonitored: false,
+            branch: "newDefaultBranch",
+            targetReference: null,
+            tags: [],
+            attributes: {},
+            remediation: {}
+          }, status: 200 })
+
+        const res = await updateProject(requestManager, "af137b96-6966-46c1-826b-2e79ac49bbxx", "af137b96-6966-46c1-826b-2e79ac49bbd9", {branch: "newDefaultBranch"});
+        expect(res.branch).toMatchSnapshot()
+        
+    }, 5000);
+
+    it('Error if the requests fails', async () => {
+
+        jest.spyOn(requestManager, 'request').mockResolvedValue({statusCode : 500, data: {}})
+        expect(async () => {await updateProject(requestManager, "af137b96-6966-46c1-826b-2e79ac49bbxx", "af137b96-6966-46c1-826b-2e79ac49bbd9", {branch: "newDefaultBranch"})}).rejects.toThrowError('Expected a 200 response, instead received: {"data":{},"status":500}')
+
+    }, 5000);
+
+})
+

--- a/test/system/projects.test.ts
+++ b/test/system/projects.test.ts
@@ -1,0 +1,34 @@
+import { requestsManager } from 'snyk-request-manager';
+import { updateProject } from '../../src/lib';
+
+const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
+const PROJECT_ID = process.env.TEST_PROJECT_ID as string;
+const ORG_ID = process.env.TEST_ORG_ID as string;
+
+jest.unmock('snyk-request-manager');
+jest.requireActual('snyk-request-manager');
+
+
+describe('UpdateProject - e2e', () => {
+    const OLD_ENV = process.env;
+    process.env.SNYK_API = SNYK_API_TEST;
+    process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+    const requestManager = new requestsManager({
+      userAgentPrefix: 'snyk-api-import:tests',
+    });
+    afterAll(async () => {
+      process.env = { ...OLD_ENV };
+    }, 1000);
+
+    it('Update project branch e2e', async () => {
+
+        let res = await updateProject(requestManager, ORG_ID, PROJECT_ID, {branch: "newDefaultBranch"});
+        expect(res.branch).toEqual("newDefaultBranch") 
+
+        res = await updateProject(requestManager, ORG_ID, PROJECT_ID, {branch: "main"});
+        expect(res.branch).toEqual("main") 
+      
+    }, 5000);
+
+})
+


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Adding support for update the project branch using the v1 api.
The new function require a new env variable TEST_PROJECT_ID (already added to onepassword and circle)
Add e2e and unit tests

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [TECHSERV-3368](https://snyksec.atlassian.net/jira/software/c/projects/TECHSERV/boards/387?modal=detail&selectedIssue=TECHSERV-3368)

### Screenshots

_Visuals that may help the reviewer_
