### PR TITLE
feat: add function to get feature flags from a snyk org

### DIFF
--- a/src/lib/get-feature-flag-for-snyk-org.ts
+++ b/src/lib/get-feature-flag-for-snyk-org.ts
@@ -1,0 +1,40 @@
+import { requestsManager } from 'snyk-request-manager';
+import * as debugLib from 'debug';
+
+const debug = debugLib('snyk:get-feature-flag');
+
+export async function getFeatureFlag(
+  requestManager: requestsManager,
+  featureFlagName: string,
+  orgId: string,
+): Promise<boolean> {
+  debug(
+    `Checking if feature flag ${featureFlagName} is enabled for Snyk org ${orgId}`,
+  );
+  try {
+    const url = `cli-config/feature-flags/${featureFlagName}?org=${orgId}`;
+    const res = await requestManager.request({
+      verb: 'get',
+      url: url,
+      useRESTApi: false,
+    });
+    debug(`Feature flag ${featureFlagName} is enabled for Org ${orgId}`);
+    return res.data['ok'];
+  } catch (err) {
+    if (err instanceof Error) {
+      //Currently this is the only way to distinguish between an actual 403 and a 403 that is returned when an org hasn't got that FF enabled
+      if (JSON.stringify(err).search('"ok":false') > 0) {
+        debug(
+          `Feature flag ${featureFlagName} is not enabled for Org ${orgId}, please advise with your Snyk representative`,
+        );
+      } else {
+        debug(
+          `Could not fetch the ${featureFlagName} feature flag for ${orgId}\n ${JSON.stringify(
+            err,
+          )}`,
+        );
+      }
+    }
+    return false;
+  }
+}

--- a/test/lib/get-feature-flag.test.ts
+++ b/test/lib/get-feature-flag.test.ts
@@ -1,0 +1,48 @@
+import { requestsManager } from 'snyk-request-manager';
+import { getFeatureFlag } from '../../src/lib/get-feature-flag-for-snyk-org';
+
+jest.unmock('snyk-request-manager');
+jest.requireActual('snyk-request-manager');
+const orgId = process.env.TEST_ORG_ID as string;
+
+describe('getFeatureFlag', () => {
+  const requestManager = new requestsManager({
+    userAgentPrefix: 'snyk-api-import:tests',
+  });
+  afterAll(async () => {
+    jest.clearAllMocks();
+  }, 1000);
+
+  it('get feature flag for org - mock', async () => {
+    jest.spyOn(requestManager, 'request').mockResolvedValueOnce({
+      data: {
+        ok: true,
+      },
+    });
+
+    const res = await getFeatureFlag(
+      requestManager,
+      'existingFeatureFlag',
+      'someOrgId',
+    );
+    expect(res).toBeTruthy();
+  });
+
+  it('Error if the request fails with generic 403 - not a real Snyk org', async () => {
+    const res = await getFeatureFlag(
+      requestManager,
+      'nonEnabledFeatureFlag',
+      '0000',
+    );
+    expect(res).toBeFalsy();
+  }, 20000);
+
+  it('Error if the request fails with a 403 that indicates the FF is not enabled for a real org', async () => {
+    const res = await getFeatureFlag(
+      requestManager,
+      'nonEnabledFeatureFlag',
+      orgId,
+    );
+    expect(res).toBeFalsy();
+  }, 20000);
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Adds a function to fetch a FF from Snyk for a given org

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Jira ticket](https://snyksec.atlassian.net/browse/TECHSERV-3388)