### PR TITLE
chore: move FF API calls to src/lib/api

### DIFF
--- a/src/lib/api/feature-flags/index.ts
+++ b/src/lib/api/feature-flags/index.ts
@@ -1,4 +1,4 @@
-import { requestsManager } from 'snyk-request-manager';
+import type { requestsManager } from 'snyk-request-manager';
 import * as debugLib from 'debug';
 
 const debug = debugLib('snyk:get-feature-flag');

--- a/test/lib/api/feature-flags/index.test.ts
+++ b/test/lib/api/feature-flags/index.test.ts
@@ -1,5 +1,5 @@
 import { requestsManager } from 'snyk-request-manager';
-import { getFeatureFlag } from '../../src/lib/get-feature-flag-for-snyk-org';
+import { getFeatureFlag } from '../../../../src/lib/api/feature-flags';
 
 jest.unmock('snyk-request-manager');
 jest.requireActual('snyk-request-manager');
@@ -8,6 +8,7 @@ const orgId = process.env.TEST_ORG_ID as string;
 describe('getFeatureFlag', () => {
   const requestManager = new requestsManager({
     userAgentPrefix: 'snyk-api-import:tests',
+    maxRetryCount: 1,
   });
   afterAll(async () => {
     jest.resetAllMocks();


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Move Snyk Api call code to `src/lib/api`