### PR TITLE
chore: reset mocks to original implementation

### DIFF
--- a/test/lib/api/feature-flags/index.test.ts
+++ b/test/lib/api/feature-flags/index.test.ts
@@ -10,9 +10,10 @@ describe('getFeatureFlag', () => {
     userAgentPrefix: 'snyk-api-import:tests',
     maxRetryCount: 1,
   });
-  afterAll(async () => {
-    jest.resetAllMocks();
-  }, 1000);
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
 
   it('get feature flag for org - mock', async () => {
     jest.spyOn(requestManager, 'request').mockResolvedValueOnce({

--- a/test/lib/api/project/index.test.ts
+++ b/test/lib/api/project/index.test.ts
@@ -10,7 +10,7 @@ describe('UpdateProject', () => {
     process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
   });
   afterAll(() => {
-    jest.resetAllMocks();
+    jest.restoreAllMocks();
     process.env = { ...OLD_ENV };
   }, 1000);
 

--- a/test/lib/import-projects.test.ts
+++ b/test/lib/import-projects.test.ts
@@ -137,7 +137,7 @@ describe('importTarget()', () => {
   const requestManager = new requestsManager({
     userAgentPrefix: 'snyk-api-import:tests',
   });
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Target is always sanitized', async () => {

--- a/test/lib/org.test.ts
+++ b/test/lib/org.test.ts
@@ -93,9 +93,10 @@ describe('listTargets', () => {
   const requestManager = new requestsManager({
     userAgentPrefix: 'snyk-api-import:tests',
   });
-  afterAll(async () => {
-    jest.resetAllMocks();
-  }, 1000);
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
 
   it('list the targets in a given Org without pagination - mock', async () => {
     jest.spyOn(requestManager, 'request').mockResolvedValue({

--- a/test/lib/orgs.test.ts
+++ b/test/lib/orgs.test.ts
@@ -16,7 +16,7 @@ describe('Orgs API', () => {
   const requestManager = new requestsManager({
     userAgentPrefix: 'snyk-api-import:tests',
   });
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
 

--- a/test/scripts/generate-org-data.test.ts
+++ b/test/scripts/generate-org-data.test.ts
@@ -9,7 +9,7 @@ describe('generateOrgImportDataFile Github script', () => {
     __dirname + '/group-groupIdExample-github-com-orgs.json',
     __dirname + '/group-groupIdExample-github-enterprise-orgs.json',
   ];
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
 
@@ -142,7 +142,7 @@ describe('generateOrgImportDataFile Gitlab script', () => {
   const filesToCleanup: string[] = [
     __dirname + '/group-groupIdExample-gitlab-orgs.json',
   ];
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
 
@@ -233,7 +233,7 @@ describe('generateOrgImportDataFile Bitbucket Cloud script', () => {
   const filesToCleanup: string[] = [
     __dirname + '/group-groupIdExample-bitbucket-cloud-orgs.json',
   ];
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
 

--- a/test/system/help.test.ts
+++ b/test/system/help.test.ts
@@ -7,7 +7,7 @@ describe('`snyk-api-import help <...>`', () => {
   process.env.SNYK_API = process.env.SNYK_API_TEST;
   process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
 
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {

--- a/test/system/import:data.test.ts
+++ b/test/system/import:data.test.ts
@@ -6,7 +6,7 @@ const main = './dist/index.js'.replace(/\//g, sep);
 
 describe('`snyk-api-import import:data <...>`', () => {
   const OLD_ENV = process.env;
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {

--- a/test/system/list:imported.test.ts
+++ b/test/system/list:imported.test.ts
@@ -11,7 +11,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
   const GROUP_ID = process.env.TEST_GROUP_ID as string;
   const ORG_ID = process.env.TEST_ORG_ID as string;
 
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {

--- a/test/system/orgs:create.test.ts
+++ b/test/system/orgs:create.test.ts
@@ -9,7 +9,7 @@ describe('`snyk-api-import help <...>`', () => {
   const OLD_ENV = process.env;
   const GROUP_ID = process.env.TEST_GROUP_ID as string;
 
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {

--- a/test/system/orgs:data/bitbucket.test.ts
+++ b/test/system/orgs:data/bitbucket.test.ts
@@ -5,7 +5,7 @@ const main = './dist/index.js'.replace(/\//g, path.sep);
 
 describe('General `snyk-api-import orgs:data <...>`', () => {
   const OLD_ENV = process.env;
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Generates orgs data as expected for Bitbucket Server', (done) => {

--- a/test/system/orgs:data/errors.test.ts
+++ b/test/system/orgs:data/errors.test.ts
@@ -4,7 +4,7 @@ const main = './dist/index.js'.replace(/\//g, path.sep);
 
 describe('General `snyk-api-import orgs:data <...>`', () => {
   const OLD_ENV = process.env;
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Shows error when missing groupId', (done) => {

--- a/test/system/orgs:data/generic.test.ts
+++ b/test/system/orgs:data/generic.test.ts
@@ -4,7 +4,7 @@ const main = './dist/index.js'.replace(/\//g, path.sep);
 
 describe('General `snyk-api-import orgs:data <...>`', () => {
   const OLD_ENV = process.env;
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Shows help text as expected', (done) => {

--- a/test/system/orgs:data/github.test.ts
+++ b/test/system/orgs:data/github.test.ts
@@ -5,7 +5,7 @@ const main = './dist/index.js'.replace(/\//g, path.sep);
 
 describe('General `snyk-api-import orgs:data <...>`', () => {
   const OLD_ENV = process.env;
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Generates orgs data as expected', (done) => {

--- a/test/system/orgs:data/gitlab.test.ts
+++ b/test/system/orgs:data/gitlab.test.ts
@@ -5,7 +5,7 @@ const main = './dist/index.js'.replace(/\//g, path.sep);
 
 describe('General `snyk-api-import orgs:data <...>`', () => {
   const OLD_ENV = process.env;
-  afterAll(async () => {
+  afterAll(() => {
     process.env = { ...OLD_ENV };
   });
   it('Generates orgs data as expected for Gitlab', (done) => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Restore mocks back to original & drop unnecessary async