### PR TITLE
feat: assume integration type = source

### DIFF
--- a/docs/import-data.md
+++ b/docs/import-data.md
@@ -38,9 +38,9 @@ This is a util that can help generate the import json data needed by the import 
   - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
 
 3. Run the command to generate import data:
- - **Github.com:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github --integrationType=github`
- - **Github Enterprise Server:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise --integrationType=github-enterprise --sourceUrl=https://ghe.custom.com`
- - **Github Enterprise Cloud:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise --integrationType=github-enterprise`
+ - **Github.com:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github`
+ - **Github Enterprise Server:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise --sourceUrl=https://ghe.custom.com`
+ - **Github Enterprise Cloud:** `DEBUG=snyk* GITHUB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=github-enterprise`
 
 4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
 
@@ -67,8 +67,8 @@ This is a util that can help generate the import json data needed by the import 
   - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
 
 3. Run the command to generate import data:
- - **Gitlab.com:** `DEBUG=snyk* GITLAB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=gitlab --integrationType=gitlab`
- - **Hosted Gitlab:** `DEBUG=snyk* GITLAB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=gitlab --integrationType=gitlab --sourceUrl=https://gitlab.custom.com`
+ - **Gitlab.com:** `DEBUG=snyk* GITLAB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=gitlab `
+ - **Hosted Gitlab:** `DEBUG=snyk* GITLAB_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=gitlab --sourceUrl=https://gitlab.custom.com`
 
 4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
 
@@ -97,8 +97,8 @@ This is a util that can help generate the import json data needed by the import 
   - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
 
 3. Run the command to generate import data:
- - **dev.azure.com:** `DEBUG=snyk* AZURE_TOKEN=*** SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=azure-repos --integrationType=azure-repos`
- - **Hosted Azure:** `DEBUG=snyk* AZURE_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=azure-repos --integrationType=azure-repos --sourceUrl=https://azure.custom.com`
+ - **dev.azure.com:** `DEBUG=snyk* AZURE_TOKEN=*** SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=azure-repos`
+ - **Hosted Azure:** `DEBUG=snyk* AZURE_TOKEN=***  SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=azure-repos --sourceUrl=https://azure.custom.com`
 
 4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
 
@@ -127,7 +127,7 @@ This is a util that can help generate the import json data needed by the import 
   - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
 
 3. Run the command to generate import data:
- - **Bitbucket Server:** `DEBUG=snyk* BITBUCKET_SERVER_TOKEN=*** SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=bitbucket-server --integrationType=bitbucket-server --sourceUrl=https://bitbucket-server.dev.example.com`
+ - **Bitbucket Server:** `DEBUG=snyk* BITBUCKET_SERVER_TOKEN=*** SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=bitbucket-server --sourceUrl=https://bitbucket-server.dev.example.com`
 
 4. Use the generated data to feed into [import] command (/import.md) to generate kick off the import.
 
@@ -160,7 +160,7 @@ export BITBUCKET_CLOUD_PASSWORD=your_bitbucket_cloud_password
   - All organization IDs can be found by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
 
 3. Run the command to generate import data:
- - **Bitbucket Cloud:** `DEBUG=snyk* BITBUCKET_CLOUD_USERNAME=*** BITBUCKET_CLOUD_PASSWORD=*** SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=bitbucket-cloud --integrationType=bitbucket-cloud`
+ - **Bitbucket Cloud:** `DEBUG=snyk* BITBUCKET_CLOUD_USERNAME=*** BITBUCKET_CLOUD_PASSWORD=*** SNYK_TOKEN=*** snyk-api-import import:data --orgsData=path/to/snyk-orgs.json --source=bitbucket-cloud`
 
 4. Use the generated data to feed into [import command](/import.md) to generate kick off the import.
 

--- a/docs/mirror-bitbucket-cloud.md
+++ b/docs/mirror-bitbucket-cloud.md
@@ -6,7 +6,7 @@ Please refer to individual documentation pages for more detailed info, however t
 1. `export BITBUCKET_CLOUD_USERNAME=***`, `export BITBUCKET_CLOUD_PASSWORD=***` and `export SNYK_TOKEN=***`
 2. Generate organization data e.g. `snyk-api-import orgs:data --source=bitbucket-cloud --groupId=<snyk_group_id>` [Full instructions](./orgs.md)
 3. Create organizations in Snyk `snyk-api-import orgs:create --file=orgs.json` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
-4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-cloud --integrationType=bitbucket-cloud` [Full instructions](./import-data.md)
+4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-cloud` [Full instructions](./import-data.md)
 5. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)
 
 ## Re-importing new repos & orgs only while Mirroring
@@ -14,7 +14,7 @@ Once initial import is complete you may want to periodically check for new repos
 1. `export BITBUCKET_CLOUD_USERNAME=***`, `export BITBUCKET_CLOUD_PASSWORD=***` and `export SNYK_TOKEN=***`
 2. Generate organization data in Snyk and skip any that do not have any repos via `--skipEmptyOrg` `snyk-api-import orgs:data --source=bitbucket-cloud --groupId=<snyk_group_id> --skipEmptyOrg` [Full instructions](./orgs.md)
 3. Create organizations in Snyk and this time skip any that have been created already with `--noDuplicateNames` parameter `snyk-api-import orgs:create --file=orgs.json --noDuplicateNames` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
-4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-cloud --integrationType=bitbucket-cloud` [Full instructions](./import-data.md)
+4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-cloud` [Full instructions](./import-data.md)
 5. Optional. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
 6. Run import `DEBUG=*snyk* snyk-api-import import` [Full instructions](./import.md)

--- a/docs/mirror-bitbucket-server.md
+++ b/docs/mirror-bitbucket-server.md
@@ -6,7 +6,7 @@ Please refer to individual documentation pages for more detailed info, however t
 1. `export BITBUCKET_SERVER_TOKEN=***` and `export SNYK_TOKEN=***`
 2. Generate organization data e.g. `snyk-api-import orgs:data --source=bitbucket-server --groupId=<snyk_group_id>` [Full instructions](./orgs.md)
 3. Create organizations in Snyk `snyk-api-import orgs:create --file=orgs.json` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
-4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-server --integrationType=bitbucket-server` [Full instructions](./import-data.md)
+4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-server` [Full instructions](./import-data.md)
 5. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)
 
 ## Re-importing new repos & orgs only while Mirroring
@@ -14,7 +14,7 @@ Once initial import is complete you may want to periodically check for new repos
 1. `export BITBUCKET_SERVER_TOKEN=***` and `export SNYK_TOKEN=***`
 2. Generate organization data in Snyk and skip any that do not have any repos via `--skipEmptyOrg` `snyk-api-import orgs:data --source=bitbucket-server --groupId=<snyk_group_id> --skipEmptyOrg` [Full instructions](./orgs.md)
 3. Create organizations in Snyk and this time skip any that have been created already with `--noDuplicateNames` parameter `snyk-api-import orgs:create --file=orgs.json --noDuplicateNames` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
-4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-server --integrationType=bitbucket-server` [Full instructions](./import-data.md)
+4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=bitbucket-server` [Full instructions](./import-data.md)
 5. Optional. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
 6. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)

--- a/docs/mirror-github.md
+++ b/docs/mirror-github.md
@@ -1,6 +1,6 @@
 # Mirroring Github.com / Github Enterprise organizations and repos in Snyk
 
-You will need your Snyk API token, with correct scope & [admin access for all Organizations](https://snyk.docs.apiary.io/#reference/import-projects/import/import-targets) you are importing to. As Github is both an auth & integration, how the integration is done has an effect on usage: 
+You will need your Snyk API token, with correct scope & [admin access for all Organizations](https://snyk.docs.apiary.io/#reference/import-projects/import/import-targets) you are importing to. As Github is both an auth & integration, how the integration is done has an effect on usage:
   - For users importing via [Github Snyk integration](https://docs.snyk.io/integrations/git-repository-scm-integrations/github-integration#setting-up-a-github-integration) use your **personal Snyk API token** (Service Accounts are not supported for Github integration imports via API as this is a personal auth token only accessible to the user)
   - For Github Enterprise Snyk integration with a url & token (for Github.com, Github Enterprise Cloud & Github Enterprise hosted) use a **Snyk API service account token**
 
@@ -11,7 +11,7 @@ Please refer to individual documentation pages for more detailed info, however t
 1. `export GITHUB_TOKEN=***` and `export SNYK_TOKEN=***`
 2. Generate organization data e.g. `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id>` [Full instructions](./orgs.md)
 3. Create organizations in Snyk `snyk-api-import orgs:create --file=orgs.json` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
-4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=github --integrationType=github` [Full instructions](./import-data.md)
+4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=github` [Full instructions](./import-data.md)
 5. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)
 
 ## Re-importing new repos & organizations only while mirroring
@@ -19,7 +19,7 @@ Once initial import is complete you may want to periodically check for new repos
 1. `export GITHUB_TOKEN=***` and `export SNYK_TOKEN=***`
 2. Generate organization data in Snyk and skip any that do not have any repos via `--skipEmptyOrg` `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id> --skipEmptyOrg` [Full instructions](./orgs.md)
 3. Create organizations in Snyk and this time skip any that have been created already with `--noDuplicateNames` parameter `snyk-api-import orgs:create --file=orgs.json --noDuplicateNames` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
-4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=github --integrationType=github` [Full instructions](./import-data.md)
+4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=github` [Full instructions](./import-data.md)
 5. Optional. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
 6. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)

--- a/docs/mirror-gitlab.md
+++ b/docs/mirror-gitlab.md
@@ -14,7 +14,7 @@ Once initial import is complete you may want to periodically check for new repos
 1. `export GITLAB_TOKEN=***` and `export SNYK_TOKEN=***`
 2. Generate organization data in Snyk and skip any that do not have any repos via `--skipEmptyOrg` `snyk-api-import orgs:data --source=gitlab --groupId=<snyk_group_id> --skipEmptyOrg` [Full instructions](./orgs.md)
 3. Create organizations in Snyk and this time skip any that have been created already with `--noDuplicateNames` parameter `snyk-api-import orgs:create --file=orgs.json --noDuplicateNames` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
-4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=gitlab --integrationType=gitlab` [Full instructions](./import-data.md)
+4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=gitlab` [Full instructions](./import-data.md)
 5. Optional. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
 `snyk-api-import-macos list:imported --integrationType=gitlab --groupId=<snyk_group_id>`
 6. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)

--- a/src/cmds/import.ts
+++ b/src/cmds/import.ts
@@ -1,7 +1,7 @@
 import * as debugLib from 'debug';
 import * as _ from 'lodash';
 import * as yargs from 'yargs';
-import { CommandResult } from '../lib/types';
+import type { CommandResult } from '../lib/types';
 
 const debug = debugLib('snyk:import-projects-script');
 

--- a/src/cmds/import:data.ts
+++ b/src/cmds/import:data.ts
@@ -3,11 +3,8 @@ import * as yargs from 'yargs';
 import { getLoggingPath } from '../lib/get-logging-path';
 const debug = debugLib('snyk:generate-data-script');
 
-import {
-  CreatedOrg,
-  SupportedIntegrationTypesImportData,
-  CommandResult,
-} from '../lib/types';
+import { SupportedIntegrationTypesImportData } from '../lib/types';
+import type { CreatedOrg, CommandResult } from '../lib/types';
 import { loadFile } from '../load-file';
 import { generateTargetsImportDataFile } from '../scripts/generate-targets-data';
 
@@ -31,12 +28,6 @@ export const builder = {
     default: undefined,
     desc: 'Custom base url for the source API that can list organizations (e.g. Github Enterprise url)',
   },
-  integrationType: {
-    required: true,
-    default: undefined,
-    choices: [...Object.values(SupportedIntegrationTypesImportData)],
-    desc: 'The configured integration type on the created Snyk Org to use for generating import targets data. Applies to all targets.',
-  },
 };
 
 const entityName: {
@@ -53,7 +44,6 @@ const entityName: {
 export async function generateOrgData(
   source: SupportedIntegrationTypesImportData,
   orgsData: string,
-  integrationType: SupportedIntegrationTypesImportData,
   sourceUrl: string,
 ): Promise<CommandResult> {
   try {
@@ -76,7 +66,6 @@ export async function generateOrgData(
     const res = await generateTargetsImportDataFile(
       source,
       orgsDataJson,
-      integrationType,
       sourceUrl,
     );
     const targetsMessage =
@@ -103,18 +92,12 @@ export async function generateOrgData(
 export async function handler(argv: {
   source: SupportedIntegrationTypesImportData;
   orgsData: string;
-  integrationType: SupportedIntegrationTypesImportData;
   sourceUrl: string;
 }): Promise<void> {
-  const { source, orgsData, integrationType, sourceUrl } = argv;
+  const { source, orgsData, sourceUrl } = argv;
   debug('ℹ️  Options: ' + JSON.stringify(argv));
 
-  const res = await generateOrgData(
-    source,
-    orgsData,
-    integrationType,
-    sourceUrl,
-  );
+  const res = await generateOrgData(source, orgsData, sourceUrl);
 
   if (res.exitCode === 1) {
     debug('Failed to create organizations.\n' + res.message);

--- a/src/cmds/list:imported.ts
+++ b/src/cmds/list:imported.ts
@@ -28,7 +28,7 @@ export const builder = {
     required: true, // TODO: allow to not set any type to return all
     default: [...Object.values(SupportedIntegrationTypesToListSnykTargets)],
     choices: [...Object.values(SupportedIntegrationTypesToListSnykTargets)],
-    desc: 'The configured integration type (source of the projects in Snyk e.g. Github, Github Enterprise.). This will be used to pick the correct integrationID from each org in Snyk E.g. --integrationType=github --integrationType=github-enterprise',
+    desc: 'The configured integration type (source of the projects in Snyk e.g. Github, Github Enterprise.). This will be used to pick the correct integrationID from each org in Snyk E.g. --integrationType=github, --integrationType=github-enterprise',
   },
 };
 

--- a/src/scripts/generate-targets-data.ts
+++ b/src/scripts/generate-targets-data.ts
@@ -83,7 +83,6 @@ function validateRequiredOrgData(
 export async function generateTargetsImportDataFile(
   source: SupportedIntegrationTypesImportData,
   orgsData: CreatedOrg[],
-  integrationType: SupportedIntegrationTypesImportData,
   sourceUrl?: string,
 ): Promise<{ targets: ImportTarget[]; fileName: string }> {
   const targetsData: ImportTarget[] = [];
@@ -104,7 +103,7 @@ export async function generateTargetsImportDataFile(
       entities.forEach((entity) => {
         targetsData.push({
           target: entity,
-          integrationId: integrations[integrationType],
+          integrationId: integrations[source],
           orgId,
         });
       });

--- a/test/scripts/generate-targets-data.test.ts
+++ b/test/scripts/generate-targets-data.test.ts
@@ -36,7 +36,6 @@ describe('generateTargetsImportDataFile Github script', () => {
     const res = await generateTargetsImportDataFile(
       SupportedIntegrationTypesImportData.GITHUB,
       orgsData,
-      SupportedIntegrationTypesImportData.GITHUB,
     );
     expect(res.fileName).toEqual('github-import-targets.json');
     expect(res.targets.length > 0).toBeTruthy();
@@ -75,7 +74,6 @@ describe('generateTargetsImportDataFile Github script', () => {
     const res = await generateTargetsImportDataFile(
       SupportedIntegrationTypesImportData.GHE,
       orgsData,
-      SupportedIntegrationTypesImportData.GHE,
       GHE_URL,
     );
     expect(res.fileName).toEqual('github-enterprise-import-targets.json');
@@ -109,7 +107,6 @@ describe('generateTargetsImportDataFile Github script', () => {
       generateTargetsImportDataFile(
         SupportedIntegrationTypesImportData.GITHUB,
         orgsData,
-        SupportedIntegrationTypesImportData.GITHUB,
       ),
     ).rejects.toThrow(
       'No targets could be generated. Check the error output & try again.',
@@ -147,7 +144,6 @@ describe('generateTargetsImportDataFile Github script', () => {
     const res = await generateTargetsImportDataFile(
       SupportedIntegrationTypesImportData.GITHUB,
       orgsData,
-      SupportedIntegrationTypesImportData.GITHUB,
     );
     expect(res.fileName).toEqual('github-import-targets.json');
     expect(res.targets.length > 0).toBeTruthy();
@@ -195,7 +191,6 @@ describe('generateTargetsImportDataFile Gitlab script', () => {
     const res = await generateTargetsImportDataFile(
       SupportedIntegrationTypesImportData.GITLAB,
       orgsData,
-      SupportedIntegrationTypesImportData.GITLAB,
       GITLAB_BASE_URL,
     );
     expect(res.fileName).toEqual('gitlab-import-targets.json');
@@ -232,7 +227,6 @@ describe('generateTargetsImportDataFile Gitlab script', () => {
       generateTargetsImportDataFile(
         SupportedIntegrationTypesImportData.GITLAB,
         orgsData,
-        SupportedIntegrationTypesImportData.GITLAB,
         GITLAB_BASE_URL,
       ),
     ).rejects.toThrow(
@@ -273,7 +267,6 @@ describe('generateTargetsImportDataFile Gitlab script', () => {
     const res = await generateTargetsImportDataFile(
       SupportedIntegrationTypesImportData.GITLAB,
       orgsData,
-      SupportedIntegrationTypesImportData.GITLAB,
       GITLAB_BASE_URL,
     );
     expect(res.fileName).toEqual('gitlab-import-targets.json');

--- a/test/system/import:data.test.ts
+++ b/test/system/import:data.test.ts
@@ -26,30 +26,25 @@ describe('`snyk-api-import import:data <...>`', () => {
         expect(err).toBeNull();
         expect(stderr).toEqual('');
         expect(stdout.trim()).toMatchInlineSnapshot(`
-"index.js import:data
+          "index.js import:data
 
-Generate data required for targets to be imported via API to create Snyk
-projects.
+          Generate data required for targets to be imported via API to create Snyk
+          projects.
 
 
-Options:
-  --version          Show version number                               [boolean]
-  --help             Show help                                         [boolean]
-  --orgsData         Path to organizations data file generated with
-                     \\"orgs:create\\" command                            [required]
-  --source           The source of the targets to be imported e.g. Github,
-                     Github Enterprise, Gitlab, Azure. This will be used to make
-                     an API call to list all available entities per org
-    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
-                      \\"bitbucket-server\\", \\"bitbucket-cloud\\"] [default: \\"github\\"]
-  --sourceUrl        Custom base url for the source API that can list
-                     organizations (e.g. Github Enterprise url)
-  --integrationType  The configured integration type on the created Snyk Org to
-                     use for generating import targets data. Applies to all
-                     targets.
-    [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
-                                          \\"bitbucket-server\\", \\"bitbucket-cloud\\"]"
-`);
+          Options:
+            --version    Show version number                                     [boolean]
+            --help       Show help                                               [boolean]
+            --orgsData   Path to organizations data file generated with \\"orgs:create\\"
+                         command                                                [required]
+            --source     The source of the targets to be imported e.g. Github, Github
+                         Enterprise, Gitlab, Azure. This will be used to make an API call
+                         to list all available entities per org
+              [required] [choices: \\"github\\", \\"github-enterprise\\", \\"gitlab\\", \\"azure-repos\\",
+                                \\"bitbucket-server\\", \\"bitbucket-cloud\\"] [default: \\"github\\"]
+            --sourceUrl  Custom base url for the source API that can list organizations
+                         (e.g. Github Enterprise url)"
+        `);
       },
     ).on('exit', (code) => {
       expect(code).toEqual(0);
@@ -60,7 +55,7 @@ Options:
   it('Generates repo data as expected for Gitlab', (done) => {
     const orgDataFile = 'test/system/fixtures/org-data/orgs.json';
     exec(
-      `node ${main} import:data --source=gitlab --integrationType=gitlab --sourceUrl=${process.env.TEST_GITLAB_BASE_URL} --orgsData=${orgDataFile}`,
+      `node ${main} import:data --source=gitlab --sourceUrl=${process.env.TEST_GITLAB_BASE_URL} --orgsData=${orgDataFile}`,
       {
         env: {
           PATH: process.env.PATH,
@@ -86,7 +81,7 @@ Options:
     const orgDataFile =
       'test/system/fixtures/org-data/bitbucket-server-orgs.json';
     exec(
-      `node ${main} import:data --source=bitbucket-server --integrationType=bitbucket-server --sourceUrl=${process.env.BBS_SOURCE_URL} --orgsData=${orgDataFile}`,
+      `node ${main} import:data --source=bitbucket-server --sourceUrl=${process.env.BBS_SOURCE_URL} --orgsData=${orgDataFile}`,
       {
         env: {
           PATH: process.env.PATH,
@@ -112,7 +107,7 @@ Options:
     const orgDataFile =
       'test/system/fixtures/org-data/bitbucket-cloud-orgs.json';
     exec(
-      `node ${main} import:data --source=bitbucket-cloud --integrationType=bitbucket-cloud --orgsData=${orgDataFile}`,
+      `node ${main} import:data --source=bitbucket-cloud --orgsData=${orgDataFile}`,
       {
         env: {
           PATH: process.env.PATH,
@@ -135,23 +130,9 @@ Options:
       done();
     });
   }, 50000);
-  it('Shows error when missing source type', (done) => {
-    exec(`node ${main} import:data --source=github`, (err, stdout, stderr) => {
-      expect(err!.message).toMatch(
-        `Missing required arguments: orgsData, integrationType`,
-      );
-      expect(stderr).toMatch(
-        `Missing required arguments: orgsData, integrationType`,
-      );
-      expect(stdout).toEqual('');
-    }).on('exit', (code) => {
-      expect(code).toEqual(1);
-      done();
-    });
-  });
   it('Shows error when missing loading non existent file', (done) => {
     exec(
-      `node ${main} import:data --source=bitbucket-cloud --integrationType=bitbucket-cloud --orgsData=non-existent.json`,
+      `node ${main} import:data --source=bitbucket-cloud --orgsData=non-existent.json`,
       {
         env: {
           PATH: process.env.PATH,

--- a/test/system/list:imported.test.ts
+++ b/test/system/list:imported.test.ts
@@ -38,7 +38,7 @@ describe('`snyk-api-import list:imported <...>`', () => {
           --integrationType  The configured integration type (source of the projects in
                              Snyk e.g. Github, Github Enterprise.). This will be used to
                              pick the correct integrationID from each org in Snyk E.g.
-                             --integrationType=github
+                             --integrationType=github,
                              --integrationType=github-enterprise
            [required] [choices: \\"github\\", \\"github-enterprise\\", \\"bitbucket-cloud\\", \\"gcr\\",
                     \\"docker-hub\\", \\"gitlab\\", \\"azure-repos\\", \\"bitbucket-server\\"] [default:
@@ -222,16 +222,16 @@ describe('`snyk-api-import list:imported <...>`', () => {
       },
       (err, stdout, stderr) => {
         expect(stderr).toMatchInlineSnapshot(`
-"ERROR! Failed to list imported targets in Snyk. Try running with \`DEBUG=snyk* <command> for more info\`.
-ERROR: Too many parameters: orgId or groupId must be provided, not both.
-"
-`);
+          "ERROR! Failed to list imported targets in Snyk. Try running with \`DEBUG=snyk* <command> for more info\`.
+          ERROR: Too many parameters: orgId or groupId must be provided, not both.
+          "
+        `);
         expect(err).toMatchInlineSnapshot(`
-[Error: Command failed: node ./dist/index.js list:imported --integrationType=github --orgId=foo --groupId=bar
-ERROR! Failed to list imported targets in Snyk. Try running with \`DEBUG=snyk* <command> for more info\`.
-ERROR: Too many parameters: orgId or groupId must be provided, not both.
-]
-`);
+          [Error: Command failed: node ./dist/index.js list:imported --integrationType=github --orgId=foo --groupId=bar
+          ERROR! Failed to list imported targets in Snyk. Try running with \`DEBUG=snyk* <command> for more info\`.
+          ERROR: Too many parameters: orgId or groupId must be provided, not both.
+          ]
+        `);
         expect(stdout).toEqual('');
       },
     ).on('exit', (code) => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Remove the need for customers to provide a separate integration name in Snyk vs source name, which was to support a quirk that Github.com can be configured as Github Enterprise (but point to `github.com` in Snyk)

From now on assume both are the same, which they usually are. Users will need to provide `--source=github-enterprise` for that specific scenario where the project are Github.com but in Snyk we configured as Enterprise connection.

