### PR TITLE
fix: break early if a whole batch fails to sync

### DIFF
--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -52,7 +52,7 @@ export async function syncOrg(
       res.meta.projects.failed.length == 0;
     const orgMessage = nothingToUpdate
       ? `Did not detect any changes to apply`
-      : `Processed ${res.processedTargets} targets\nUpdated ${res.meta.projects.updated.length} projects\n${res.meta.projects.failed.length} projects failed to update\nFind more information in ${res.fileName} and ${res.failedFileName}`;
+      : `Processed ${res.processedTargets} targets (${res.failedTargets} failed)\nUpdated ${res.meta.projects.updated.length} projects\n${res.meta.projects.failed.length} projects failed to update\nFind more information in ${res.fileName} and ${res.failedFileName}`;
 
     return {
       fileName: res.fileName,

--- a/src/scripts/sync/sync-projects-per-target.ts
+++ b/src/scripts/sync/sync-projects-per-target.ts
@@ -140,7 +140,7 @@ export async function bulkUpdateProjectsBranch(
         });
       }
     },
-    { concurrency: 30 },
+    { concurrency: 50 },
   );
 
   return { updated: updatedProjects, failed: failedProjects };

--- a/test/scripts/sync/sync-org-projects.test.ts
+++ b/test/scripts/sync/sync-org-projects.test.ts
@@ -117,6 +117,7 @@ describe('updateTargets', () => {
 
       // Assert
       expect(res).toStrictEqual({
+        failedTargets: 0,
         processedTargets: 1,
         meta: {
           projects: {
@@ -185,6 +186,7 @@ describe('updateTargets', () => {
 
       // Assert
       expect(res).toStrictEqual({
+        failedTargets: 0,
         processedTargets: 1,
         meta: {
           projects: {
@@ -283,6 +285,7 @@ describe('updateTargets', () => {
       // Assert
       expect(res).toStrictEqual({
         processedTargets: 1,
+        failedTargets: 0,
         meta: {
           projects: {
             updated: updated.map((u) => ({ ...u, target: testTargets[0] })),
@@ -386,6 +389,7 @@ describe('updateTargets', () => {
 
       // Assert
       expect(res).toStrictEqual({
+        failedTargets: 0,
         processedTargets: 1,
         meta: {
           projects: {
@@ -492,6 +496,7 @@ describe('updateOrgTargets', () => {
           },
         },
         processedTargets: 0,
+        failedTargets: 1,
       });
     });
   });
@@ -585,6 +590,7 @@ describe('updateOrgTargets', () => {
           },
         },
         processedTargets: 0,
+        failedTargets: 1,
       });
     });
 
@@ -682,6 +688,7 @@ describe('updateOrgTargets', () => {
           },
         },
         processedTargets: 2,
+        failedTargets: 0,
       });
       expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
       expect(listTargetsSpy).toHaveBeenCalledTimes(1);
@@ -826,6 +833,7 @@ describe('updateOrgTargets', () => {
           },
         },
         processedTargets: 2,
+        failedTargets: 0,
       });
       expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
       expect(listTargetsSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

- increase concurrent processing of targets to 50
- bail entirely with exit code 1 if a whole batch of targets fails straight away as something is likely wrong
