### PR TITLE
feat: supported manifest files per project type

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,6 +10,7 @@ export * from './get-import-path';
 export * from './get-logging-path';
 export * from './get-snyk-host';
 export * from './filter-out-existing-orgs';
+export * from './supported-project-types';
 
 export * from './source-handlers/github';
 export * from './source-handlers/gitlab';

--- a/src/lib/supported-project-types/index.ts
+++ b/src/lib/supported-project-types/index.ts
@@ -1,0 +1,1 @@
+export { getSCMSupportedManifests } from './supported-manifests';

--- a/src/lib/supported-project-types/supported-manifests.ts
+++ b/src/lib/supported-project-types/supported-manifests.ts
@@ -1,0 +1,163 @@
+export const PACKAGE_MANAGERS: {
+  [projectType: string]: {
+    manifestFiles: string[];
+    isSupported: boolean;
+    entitlement?: string;
+  };
+} = {
+  npm: {
+    manifestFiles: ['package.json'],
+    isSupported: true,
+  },
+  rubygems: {
+    manifestFiles: ['Gemfile.lock'],
+    isSupported: true,
+  },
+  yarn: {
+    manifestFiles: ['yarn.lock'],
+    isSupported: true,
+  },
+  'yarn-workspace': {
+    manifestFiles: ['yarn.lock'],
+    isSupported: true,
+  },
+  maven: {
+    manifestFiles: ['pom.xml'],
+    isSupported: true,
+  },
+  gradle: {
+    manifestFiles: ['build.gradle'],
+    isSupported: true,
+  },
+  sbt: {
+    manifestFiles: ['build.sbt'],
+    isSupported: true,
+  },
+  pip: {
+    manifestFiles: ['*req*.txt', 'requirements/*.txt'],
+    isSupported: true,
+  },
+  poetry: {
+    manifestFiles: ['pyproject.toml'],
+    isSupported: false,
+  },
+  golangdep: {
+    manifestFiles: ['Gopkg.lock'],
+    isSupported: true,
+  },
+  govendor: {
+    manifestFiles: ['vendor.json'],
+    isSupported: true,
+  },
+  gomodules: {
+    manifestFiles: ['go.mod'],
+    isSupported: true,
+  },
+  nuget: {
+    manifestFiles: [
+      'packages.config',
+      '*.csproj',
+      '*.fsproj',
+      '*.vbproj',
+      'project.json',
+      'project.assets.json',
+      '*.targets',
+      '*.props',
+      'packages*.lock.json',
+      'global.json',
+    ],
+    isSupported: true,
+  },
+  paket: {
+    manifestFiles: ['paket.dependencies'],
+    isSupported: false,
+  },
+  composer: {
+    manifestFiles: ['composer.lock'],
+    isSupported: true,
+  },
+  cocoapods: {
+    manifestFiles: ['Podfile'],
+    isSupported: true,
+  },
+  dockerfile: {
+    isSupported: true,
+    manifestFiles: [
+      '*[dD][oO][cC][kK][eE][rR][fF][iI][lL][eE]*',
+      '*Dockerfile*',
+    ],
+    entitlement: 'dockerfileFromScm', // TODO: use API to check https://snyk.docs.apiary.io/#reference/entitlements/a-specific-entitlement-by-organization/get-an-organization's-entitlement-value
+  },
+  hex: {
+    manifestFiles: ['mix.exs'],
+    isSupported: false,
+  },
+};
+
+export const CLOUD_CONFIGS: {
+  [projectType: string]: {
+    manifestFiles: string[];
+    isSupported: boolean;
+    entitlement?: string;
+  };
+} = {
+  helmconfig: {
+    manifestFiles: ['templates/*.yaml', 'templates/*.yml', 'Chart.yaml'],
+    isSupported: true,
+    entitlement: 'infrastructureAsCode',
+  },
+  k8sconfig: {
+    manifestFiles: ['*.yaml', '*.yml', '*.json'],
+    isSupported: true,
+    entitlement: 'infrastructureAsCode',
+  },
+  terraformconfig: {
+    manifestFiles: ['*.tf'],
+    isSupported: true,
+    entitlement: 'infrastructureAsCode',
+  },
+};
+
+export function getSCMSupportedManifests(
+  manifestTypes?: string[],
+  orgEntitlements: string[] = [],
+): string[] {
+  const typesWithSCMSupport = Object.entries({
+    ...PACKAGE_MANAGERS,
+    ...CLOUD_CONFIGS,
+  }).filter(([, config]) => config.isSupported);
+
+  const manifestFiles = typesWithSCMSupport.reduce(
+    (manifests, [name, config]) => {
+      if (manifestTypes && !manifestTypes.includes(name)) {
+        return manifests;
+      }
+
+      if (config.entitlement && !orgEntitlements.includes(config.entitlement)) {
+        return manifests;
+      }
+
+      config.manifestFiles.forEach((file) => manifests.add(file));
+
+      return manifests;
+    },
+    new Set<string>(),
+  );
+
+  return Array.from(manifestFiles);
+}
+
+export function getSCMSupportedProjectTypes(): string[] {
+  const supported = [];
+
+  for (const [name, entry] of Object.entries({
+    ...PACKAGE_MANAGERS,
+    ...CLOUD_CONFIGS,
+  })) {
+    if (entry.isSupported) {
+      supported.push(name);
+    }
+  }
+
+  return supported;
+}

--- a/test/lib/supported-project-types/index.test.ts
+++ b/test/lib/supported-project-types/index.test.ts
@@ -1,0 +1,109 @@
+import { getSCMSupportedManifests } from '../../../src/lib';
+import { getSCMSupportedProjectTypes } from '../../../src/lib/supported-project-types/supported-manifests';
+
+test('SCM supported manifest files for importing & auto discovery', async () => {
+  const supported = [
+    'package.json',
+    'Gemfile.lock',
+    'yarn.lock',
+    'pom.xml',
+    'build.gradle',
+    'build.sbt',
+    '*req*.txt',
+    'requirements/*.txt',
+    'Gopkg.lock',
+    'vendor.json',
+    'go.mod',
+    'packages.config',
+    '*.csproj',
+    '*.fsproj',
+    '*.vbproj',
+    'project.json',
+    'project.assets.json',
+    '*.targets',
+    '*.props',
+    'packages*.lock.json',
+    'global.json',
+    'composer.lock',
+    'Podfile',
+    '*[dD][oO][cC][kK][eE][rR][fF][iI][lL][eE]*',
+    '*Dockerfile*',
+    'templates/*.yaml',
+    'templates/*.yml',
+    'Chart.yaml',
+    '*.yaml',
+    '*.yml',
+    '*.json',
+    '*.tf',
+  ];
+
+  expect(
+    getSCMSupportedManifests(undefined, [
+      'infrastructureAsCode',
+      'dockerfileFromScm',
+    ]),
+  ).toEqual(supported);
+});
+
+test('SCM supported manifest files for specific project types', async () => {
+  expect(getSCMSupportedManifests(['rubygems'])).toEqual(['Gemfile.lock']);
+  expect(getSCMSupportedManifests(['npm', 'yarn'])).toEqual([
+    'package.json',
+    'yarn.lock',
+  ]);
+
+  expect(getSCMSupportedManifests(['pip', 'nuget'])).toEqual([
+    '*req*.txt',
+    'requirements/*.txt',
+    'packages.config',
+    '*.csproj',
+    '*.fsproj',
+    '*.vbproj',
+    'project.json',
+    'project.assets.json',
+    '*.targets',
+    '*.props',
+    'packages*.lock.json',
+    'global.json',
+  ]);
+  // Unsupported package manager requested
+  expect(getSCMSupportedManifests(['golang'])).toEqual([]);
+  expect(getSCMSupportedManifests(['unmanaged'])).toEqual([]);
+  expect(
+    getSCMSupportedManifests(['k8sconfig'], ['infrastructureAsCode']),
+  ).toEqual(['*.yaml', '*.yml', '*.json']);
+  expect(getSCMSupportedManifests(['k8sconfig'])).toEqual([]);
+  expect(
+    getSCMSupportedManifests(['helmconfig'], ['infrastructureAsCode']),
+  ).toEqual(['templates/*.yaml', 'templates/*.yml', 'Chart.yaml']);
+  expect(
+    getSCMSupportedManifests(['terraformconfig'], ['infrastructureAsCode']),
+  ).toEqual(['*.tf']);
+  expect(
+    getSCMSupportedManifests(['dockerfile'], ['dockerfileFromScm']),
+  ).toEqual(['*[dD][oO][cC][kK][eE][rR][fF][iI][lL][eE]*', '*Dockerfile*']);
+  expect(getSCMSupportedManifests(['dockerfile'])).toEqual([]);
+});
+
+test('SCM supported project types', async () => {
+  expect(getSCMSupportedProjectTypes()).toEqual([
+    'npm',
+    'rubygems',
+    'yarn',
+    'yarn-workspace',
+    'maven',
+    'gradle',
+    'sbt',
+    'pip',
+    'golangdep',
+    'govendor',
+    'gomodules',
+    'nuget',
+    'composer',
+    'cocoapods',
+    'dockerfile',
+    'helmconfig',
+    'k8sconfig',
+    'terraformconfig',
+  ]);
+});


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Library to get a list of supported manifest files per project type + project types for sync

### Notes for the reviewer

Unused for now, nothing calling it
