### PR TITLE
refactor: get clone url info

### DIFF
--- a/src/lib/source-handlers/github/get-repo-metadata.ts
+++ b/src/lib/source-handlers/github/get-repo-metadata.ts
@@ -6,10 +6,10 @@ import { getGithubBaseUrl } from './github-base-url';
 
 const debug = debugLib('snyk:get-github-defaultBranch-script');
 
-export async function getGithubReposDefaultBranch(
+export async function getGithubRepoMetaData(
   target: Target,
   host?: string,
-): Promise<string> {
+): Promise<{ branch: string; cloneUrl: string }> {
   const githubToken = getGithubToken();
   const baseUrl = getGithubBaseUrl(host);
   const octokit: Octokit = new Octokit({ baseUrl, auth: githubToken });
@@ -20,5 +20,8 @@ export async function getGithubReposDefaultBranch(
     owner: target.owner!,
     repo: target.name!,
   });
-  return response.data.default_branch as string;
+  return {
+    branch: response.data.default_branch!,
+    cloneUrl: response.data.clone_url!,
+  };
 }

--- a/src/lib/source-handlers/github/index.ts
+++ b/src/lib/source-handlers/github/index.ts
@@ -1,6 +1,6 @@
 export * from './list-organizations';
 export * from './list-repos';
 export * from './organization-is-empty';
-export * from './get-default-branch';
+export * from './get-repo-metadata';
 export * from './types';
 export * from './is-configured';

--- a/test/scripts/sync/sync-org-projects.test.ts
+++ b/test/scripts/sync/sync-org-projects.test.ts
@@ -32,7 +32,7 @@ describe('updateTargets', () => {
   let listProjectsSpy: jest.SpyInstance;
 
   beforeAll(() => {
-    githubSpy = jest.spyOn(github, 'getGithubReposDefaultBranch');
+    githubSpy = jest.spyOn(github, 'getGithubRepoMetaData');
     updateProjectsSpy = jest.spyOn(projectApi, 'updateProject');
     listProjectsSpy = jest.spyOn(lib, 'listProjects');
   }, 1000);
@@ -108,7 +108,12 @@ describe('updateTargets', () => {
       jest
         .spyOn(lib, 'listProjects')
         .mockImplementation(() => Promise.resolve(projectsAPIResponse));
-      githubSpy.mockImplementation(() => Promise.resolve(defaultBranch));
+      githubSpy.mockImplementation(() =>
+        Promise.resolve({
+          branch: defaultBranch,
+          cloneUrl: 'https://some-url.com',
+        }),
+      );
       updateProjectsSpy.mockImplementation(() =>
         Promise.resolve({ ...projectsAPIResponse, branch: defaultBranch }),
       );
@@ -176,7 +181,12 @@ describe('updateTargets', () => {
       listProjectsSpy.mockImplementation(() =>
         Promise.resolve(projectsAPIResponse),
       );
-      githubSpy.mockImplementation(() => Promise.resolve(defaultBranch));
+      githubSpy.mockImplementation(() =>
+        Promise.resolve({
+          branch: defaultBranch,
+          cloneUrl: 'https://some-url.com',
+        }),
+      );
       updateProjectsSpy.mockImplementation(() =>
         Promise.resolve({ ...projectsAPIResponse, branch: defaultBranch }),
       );
@@ -271,7 +281,12 @@ describe('updateTargets', () => {
       listProjectsSpy.mockImplementation(() =>
         Promise.resolve(projectsAPIResponse),
       );
-      githubSpy.mockImplementation(() => Promise.resolve(defaultBranch));
+      githubSpy.mockImplementation(() =>
+        Promise.resolve({
+          branch: defaultBranch,
+          cloneUrl: 'https://some-url.com',
+        }),
+      );
       updateProjectsSpy
         .mockImplementationOnce(() =>
           Promise.resolve({ ...projectsAPIResponse, branch: defaultBranch }),
@@ -370,7 +385,12 @@ describe('updateTargets', () => {
       listProjectsSpy.mockImplementation(() =>
         Promise.resolve(projectsAPIResponse),
       );
-      githubSpy.mockImplementation(() => Promise.resolve(defaultBranch));
+      githubSpy.mockImplementation(() =>
+        Promise.resolve({
+          branch: defaultBranch,
+          cloneUrl: 'https://some-url.com',
+        }),
+      );
       updateProjectsSpy
         .mockImplementationOnce(() =>
           Promise.resolve({ ...projectsAPIResponse, branch: defaultBranch }),
@@ -427,7 +447,7 @@ describe('updateOrgTargets', () => {
     listTargetsSpy = jest.spyOn(lib, 'listTargets');
     listProjectsSpy = jest.spyOn(lib, 'listProjects');
     logUpdatedProjectsSpy = jest.spyOn(updateProjectsLog, 'logUpdatedProjects');
-    githubSpy = jest.spyOn(github, 'getGithubReposDefaultBranch');
+    githubSpy = jest.spyOn(github, 'getGithubRepoMetaData');
     updateProjectSpy = jest.spyOn(projectApi, 'updateProject');
   });
   afterAll(() => {
@@ -650,7 +670,10 @@ describe('updateOrgTargets', () => {
 
       logUpdatedProjectsSpy.mockResolvedValueOnce(null);
       const defaultBranch = 'new-branch';
-      githubSpy.mockResolvedValue(defaultBranch);
+      githubSpy.mockResolvedValue({
+        branch: defaultBranch,
+        cloneUrl: 'https://some-url.com',
+      });
       const updated: syncProjectsForTarget.ProjectUpdate[] = [
         {
           projectPublicId: updatedProjectId1,
@@ -794,7 +817,10 @@ describe('updateOrgTargets', () => {
 
       logUpdatedProjectsSpy.mockResolvedValueOnce(null);
       const defaultBranch = 'new-branch';
-      githubSpy.mockResolvedValue(defaultBranch);
+      githubSpy.mockResolvedValue({
+        branch: defaultBranch,
+        cloneUrl: 'https://some-url.com',
+      });
       const updated: syncProjectsForTarget.ProjectUpdate[] = [
         {
           projectPublicId: updatedProjectId1,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Return `cloneUrl` as well as branch info