### PR TITLE
refactor: return sshUrl as well

### DIFF
--- a/src/lib/source-handlers/github/get-repo-metadata.ts
+++ b/src/lib/source-handlers/github/get-repo-metadata.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import * as debugLib from 'debug';
-import type { Target } from '../../types';
+import type { RepoMetaData, Target } from '../../types';
 import { getGithubToken } from './get-github-token';
 import { getGithubBaseUrl } from './github-base-url';
 
@@ -9,7 +9,7 @@ const debug = debugLib('snyk:get-github-defaultBranch-script');
 export async function getGithubRepoMetaData(
   target: Target,
   host?: string,
-): Promise<{ branch: string; cloneUrl: string }> {
+): Promise<RepoMetaData> {
   const githubToken = getGithubToken();
   const baseUrl = getGithubBaseUrl(host);
   const octokit: Octokit = new Octokit({ baseUrl, auth: githubToken });
@@ -23,5 +23,6 @@ export async function getGithubRepoMetaData(
   return {
     branch: response.data.default_branch!,
     cloneUrl: response.data.clone_url!,
+    sshUrl: response.data.ssh_url!,
   };
 }

--- a/src/lib/source-handlers/github/list-repos.ts
+++ b/src/lib/source-handlers/github/list-repos.ts
@@ -2,7 +2,7 @@ import { Octokit } from '@octokit/rest';
 import * as debugLib from 'debug';
 import { getGithubToken } from './get-github-token';
 import { getGithubBaseUrl } from './github-base-url';
-import { GithubRepoData } from './types';
+import type { GithubRepoData } from './types';
 
 const debug = debugLib('snyk:list-repos-script');
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -196,6 +196,12 @@ export interface SnykTargetRelationships {
   };
 }
 
+export interface RepoMetaData {
+  branch: string;
+  cloneUrl: string;
+  sshUrl: string;
+}
+
 export interface SnykTarget {
   attributes: {
     displayName: string;

--- a/test/scripts/sync/sync-org-projects.test.ts
+++ b/test/scripts/sync/sync-org-projects.test.ts
@@ -112,6 +112,7 @@ describe('updateTargets', () => {
         Promise.resolve({
           branch: defaultBranch,
           cloneUrl: 'https://some-url.com',
+          sshUrl: 'git@some-url.com',
         }),
       );
       updateProjectsSpy.mockImplementation(() =>
@@ -185,6 +186,7 @@ describe('updateTargets', () => {
         Promise.resolve({
           branch: defaultBranch,
           cloneUrl: 'https://some-url.com',
+          sshUrl: 'git@some-url.com',
         }),
       );
       updateProjectsSpy.mockImplementation(() =>
@@ -285,6 +287,7 @@ describe('updateTargets', () => {
         Promise.resolve({
           branch: defaultBranch,
           cloneUrl: 'https://some-url.com',
+          sshUrl: 'git@some-url.com',
         }),
       );
       updateProjectsSpy
@@ -389,6 +392,7 @@ describe('updateTargets', () => {
         Promise.resolve({
           branch: defaultBranch,
           cloneUrl: 'https://some-url.com',
+          sshUrl: 'git@some-url.com',
         }),
       );
       updateProjectsSpy
@@ -673,6 +677,7 @@ describe('updateOrgTargets', () => {
       githubSpy.mockResolvedValue({
         branch: defaultBranch,
         cloneUrl: 'https://some-url.com',
+        sshUrl: 'git@some-url.com',
       });
       const updated: syncProjectsForTarget.ProjectUpdate[] = [
         {
@@ -820,6 +825,7 @@ describe('updateOrgTargets', () => {
       githubSpy.mockResolvedValue({
         branch: defaultBranch,
         cloneUrl: 'https://some-url.com',
+        sshUrl: 'git@some-url.com',
       });
       const updated: syncProjectsForTarget.ProjectUpdate[] = [
         {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Return sshUrl as part of repo meta so it can be used for cloning
