### PR TITLE
fix: supported manifest types by entitlement

### DIFF
--- a/src/lib/api/project/index.ts
+++ b/src/lib/api/project/index.ts
@@ -7,10 +7,14 @@ import type { requestsManager } from 'snyk-request-manager';
 import type { SnykProject } from '../../types';
 const debug = debugLib('snyk:api-project');
 
+interface BulkProjectUpdateResponse {
+  publicId: string;
+  name: string;
+}
 export async function deleteProjects(
   orgId: string,
   projects: string[],
-): Promise<boolean> {
+): Promise<BulkProjectUpdateResponse> {
   const apiToken = getApiToken();
   if (!(orgId && projects)) {
     throw new Error(

--- a/src/lib/supported-project-types/supported-manifests.ts
+++ b/src/lib/supported-project-types/supported-manifests.ts
@@ -160,14 +160,20 @@ export function getSCMSupportedManifests(
   return Array.from(manifestFiles);
 }
 
-export function getSCMSupportedProjectTypes(): string[] {
+export function getSCMSupportedProjectTypes(
+  orgEntitlements: SnykProductEntitlement[] = [],
+): string[] {
   const supported = [];
-
-  for (const [name, entry] of Object.entries({
+  const typesWithSCMSupport = Object.entries({
     ...OPEN_SOURCE_PACKAGE_MANAGERS,
     ...CLOUD_CONFIGS,
     ...DOCKER,
-  })) {
+  }).filter(([, config]) => config.isSupported);
+
+  for (const [name, entry] of typesWithSCMSupport) {
+    if (entry.entitlement && !orgEntitlements.includes(entry.entitlement)) {
+      continue;
+    }
     if (entry.isSupported) {
       supported.push(name);
     }

--- a/test/lib/supported-project-types/index.test.ts
+++ b/test/lib/supported-project-types/index.test.ts
@@ -85,8 +85,34 @@ test('SCM supported manifest files for specific project types', async () => {
   expect(getSCMSupportedManifests(['dockerfile'])).toEqual([]);
 });
 
-test('SCM supported project types', async () => {
+test('SCM supported project types default', async () => {
   expect(getSCMSupportedProjectTypes().sort()).toEqual(
+    [
+      'npm',
+      'rubygems',
+      'yarn',
+      'yarn-workspace',
+      'maven',
+      'gradle',
+      'sbt',
+      'pip',
+      'golangdep',
+      'govendor',
+      'gomodules',
+      'nuget',
+      'composer',
+      'cocoapods',
+    ].sort(),
+  );
+});
+
+test('SCM supported project types (OS & IAC & Docker)', async () => {
+  expect(
+    getSCMSupportedProjectTypes([
+      'dockerfileFromScm',
+      'infrastructureAsCode',
+    ]).sort(),
+  ).toEqual(
     [
       'npm',
       'rubygems',


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Return supported manifest types by entitlements, by default OS project types only