### PR TITLE
fix: strip id from non Gitlab targets

### DIFF
--- a/src/generate-target-id.ts
+++ b/src/generate-target-id.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 
 import { targetProps } from './common';
-import { Target } from './lib/types';
+import type { Target } from './lib/types';
 
 export function generateTargetId(
   orgId: string,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Don't send `id` unless it is Gitlab