### PR TITLE
fix: reduce concurrency to prevent max calls stack error

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -23,3 +23,15 @@ export const targetProps = [
   'branch',
 ];
 export const targetPropsWithId = [...targetProps, 'id'];
+
+export const defaultExclusionGlobs = [
+  'fixtures',
+  'tests',
+  '__tests__',
+  'test',
+  '__test__',
+  'ci',
+  'node_modules',
+  'bower_components',
+  '.git',
+];

--- a/src/scripts/sync/clone-and-analyze.ts
+++ b/src/scripts/sync/clone-and-analyze.ts
@@ -1,6 +1,7 @@
 import * as debugLib from 'debug';
 import * as fs from 'fs';
 import * as path from 'path';
+import { defaultExclusionGlobs } from '../../common';
 
 import { find, getSCMSupportedManifests, gitClone } from '../../lib';
 import type { SnykProductEntitlement } from '../../lib/supported-project-types/supported-manifests';
@@ -14,17 +15,6 @@ import { generateProjectDiffActions } from './generate-projects-diff-actions';
 
 const debug = debugLib('snyk:clone-and-analyze');
 
-const defaultExclusionGlobs = [
-  'fixtures',
-  'tests',
-  '__tests__',
-  'test',
-  '__test__',
-  'ci',
-  'node_modules',
-  'bower_components',
-  '.git',
-];
 export async function cloneAndAnalyze(
   integrationType: SupportedIntegrationTypesUpdateProject,
   repoMetadata: RepoMetaData,

--- a/src/scripts/sync/sync-org-projects.ts
+++ b/src/scripts/sync/sync-org-projects.ts
@@ -186,7 +186,7 @@ export async function updateTargets(
   const failedProjects: ProjectUpdateFailure[] = [];
 
   const loggingPath = getLoggingPath();
-  const concurrentTargets = 100;
+  const concurrentTargets = 30;
 
   await pMap(
     targets,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Reduce concurrency to remove the callstack exceeded error when running in an org with 100k projects