### PR TITLE
feat: function to import single target for sync

### DIFF
--- a/src/scripts/sync/import-target.ts
+++ b/src/scripts/sync/import-target.ts
@@ -1,0 +1,39 @@
+import type { requestsManager } from 'snyk-request-manager';
+import * as debugLib from 'debug';
+import { defaultExclusionGlobs } from '../../common';
+import { importTarget, listIntegrations, pollImportUrls } from '../../lib';
+import type {
+  Project,
+  SupportedIntegrationTypesUpdateProject,
+  Target,
+} from '../../lib/types';
+
+const debug = debugLib('snyk:import-single-target');
+
+export async function importSingleTarget(
+  requestManager: requestsManager,
+  orgId: string,
+  integrationType: SupportedIntegrationTypesUpdateProject,
+  target: Target,
+  filesToImport: string[] = [],
+  excludeFolders?: string,
+  loggingPath?: string,
+): Promise<{ projects: Project[] }> {
+  const integrationsData = await listIntegrations(requestManager, orgId);
+  const integrationId = integrationsData[integrationType];
+  const files = filesToImport.map((f) => ({ path: f }));
+  const { pollingUrl } = await importTarget(
+    requestManager,
+    orgId,
+    integrationId,
+    target,
+    files,
+    `${excludeFolders}, ${defaultExclusionGlobs.join(',')}`,
+    loggingPath,
+  );
+
+  debug(`Polling for updates`);
+  const res = await pollImportUrls(requestManager, [pollingUrl]);
+  debug(`Finished polling, discovered ${res.projects?.length} projects`);
+  return res;
+}

--- a/test/scripts/sync/import-target.spec.ts
+++ b/test/scripts/sync/import-target.spec.ts
@@ -1,0 +1,83 @@
+import * as fs from 'fs';
+import { requestsManager } from 'snyk-request-manager';
+import { importSingleTarget } from '../../../src/scripts/sync/import-target';
+import { SupportedIntegrationTypesUpdateProject } from '../../../src/lib/types';
+import type { Project } from '../../../src/lib/types';
+import { deleteFiles } from '../../delete-files';
+import { deleteTestProjects } from '../../delete-test-projects';
+import { generateLogsPaths } from '../../generate-log-file-names';
+
+const ORG_ID = process.env.TEST_ORG_ID as string;
+const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
+
+jest.unmock('snyk-request-manager');
+jest.requireActual('snyk-request-manager');
+
+describe('Import projects script', () => {
+  const discoveredProjects: Project[] = [];
+  let logs: string[];
+  const OLD_ENV = process.env;
+  process.env.SNYK_API = SNYK_API_TEST;
+  process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+
+  afterAll(async () => {
+    await deleteTestProjects(ORG_ID, discoveredProjects);
+    await deleteFiles(logs);
+    process.env = { ...OLD_ENV };
+  }, 10000);
+
+  const requestManager = new requestsManager({
+    userAgentPrefix: 'snyk-api-import:tests',
+  });
+
+  it('succeeds to import a single target', async () => {
+    const logFiles = generateLogsPaths(__dirname, ORG_ID);
+    logs = Object.values(logFiles);
+
+    const target = {
+      name: 'ruby-with-versions',
+      owner: 'api-import-circle-test',
+      branch: 'master',
+    };
+
+    const { projects } = await importSingleTarget(
+      requestManager,
+      ORG_ID,
+      SupportedIntegrationTypesUpdateProject.GHE,
+      target,
+    );
+    expect(projects).not.toBe([]);
+    expect(projects.length).toEqual(1);
+    expect(projects[0]).toMatchObject({
+      projectUrl: expect.any(String),
+      success: true,
+      targetFile: expect.any(String),
+    });
+    const logFile = fs.readFileSync(logFiles.importLogPath, 'utf8');
+    expect(logFile).toMatch(
+      `"target":{"name":"ruby-with-versions","owner":"api-import-circle-test","branch":"master"}`,
+    );
+    discoveredProjects.push(...projects);
+  }, 2400000);
+  it('exclusions propagate to API and apply as expected', async () => {
+    const logFiles = generateLogsPaths(__dirname, ORG_ID);
+    logs = Object.values(logFiles);
+
+    const target = {
+      name: 'ruby-with-versions',
+      owner: 'api-import-circle-test',
+      branch: 'master',
+    };
+
+    const { projects } = await importSingleTarget(
+      requestManager,
+      ORG_ID,
+      SupportedIntegrationTypesUpdateProject.GHE,
+      target,
+      undefined,
+      'ruby-2.5.3-exactly',
+    );
+    expect(projects).toHaveLength(0);
+  }, 2400000);
+  it.todo('imports an individual file only if asked');
+});


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Function to import a single target with exclusions & files array. WIll be used shortly to import empty targets in `sync`