### PR TITLE
fix: fix Gitlab target check

### DIFF
--- a/src/lib/api/import/index.ts
+++ b/src/lib/api/import/index.ts
@@ -48,7 +48,7 @@ export async function importTarget(
   try {
     const body = {
       target: isGitlabTarget(target)
-        ? _.pick(target, ...targetPropsWithId)
+        ? _.pick(target, 'id', 'branch')
         : _.pick(target, ...targetProps),
       files,
       exclusionGlobs,
@@ -161,10 +161,6 @@ export async function importTargets(
 
 function isGitlabTarget(target: Target): boolean {
   const keys = Object.keys(target);
-
-  if (keys.length !== 2) {
-    return false;
-  }
   if (keys.find((k) => k === 'id') && keys.find((k) => k === 'branch')) {
     return true;
   }

--- a/test/scripts/fixtures/import-projects-gitlab.json
+++ b/test/scripts/fixtures/import-projects-gitlab.json
@@ -1,0 +1,14 @@
+{
+  "targets": [
+    {
+      "orgId": "74e2f385-a54f-491e-9034-76c53e72927a",
+      "integrationId": "5b9a5e7f-56ac-45a3-85f1-a60e887643da",
+      "target": {
+        "name": "test-maven",
+        "branch": "develop",
+        "id": 226,
+        "fork": false
+      }
+    }
+  ]
+}

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -42,8 +42,31 @@ describe('Import projects script', () => {
       targetFile: expect.any(String),
     });
     const logFile = fs.readFileSync(logFiles.importLogPath, 'utf8');
+    // Github project
     expect(logFile).toMatch(
       `"target":{"name":"ruby-with-versions","owner":"api-import-circle-test","branch":"master"}`,
+    );
+    discoveredProjects.push(...projects);
+  }, 2400000);
+
+  it.skip('succeeds to import Gitlab project from file', async () => {
+    const logFiles = generateLogsPaths(__dirname, ORG_ID);
+    logs = Object.values(logFiles);
+
+    const { projects } = await importProjects(
+      path.resolve(__dirname + `/fixtures/import-projects-gitlab.json`),
+      __dirname,
+    );
+    expect(projects).not.toBe([]);
+    expect(projects[0]).toMatchObject({
+      projectUrl: expect.any(String),
+      success: true,
+      targetFile: expect.any(String),
+    });
+    const logFile = fs.readFileSync(logFiles.importLogPath, 'utf8');
+    // Gitlab project
+    expect(logFile).toMatch(
+      `"target":{"name":"test-maven","branch":"develop"}`,
     );
     discoveredProjects.push(...projects);
   }, 2400000);


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Assuming Gitlab targets will always have 2 properties implies the tool & users created the exact correct target which is not a good assumption, dropping the check and at the same time reducing what ata is sent to the backend for Gitlab to only be `id` and `branch` in case backend validation gets stricter.

Adding an extra test for Gitlab import flow which will catch the issue next time.