### PR TITLE
refactor: ensure Snyk Code projects are not deactivated, filter them…

### DIFF
--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -40,7 +40,7 @@ export const builder = {
     required: false,
     default: SupportedProductsUpdateProject.OPEN_SOURCE,
     choices: [...Object.values(SupportedProductsUpdateProject)],
-    desc: 'List of Snyk Products to consider when syncing an SCM repo. Monitored Snyk Code repos are automatically synced already, if Snyk Code is enabled any new repo imports will include Snyk Code projects',
+    desc: 'List of Snyk Products to consider when syncing an SCM repo for deleting projects & importing new ones (default branch will be updated for all projects in a target). Monitored Snyk Code repos are automatically synced already, if Snyk Code is enabled any new repo imports will bring in Snyk Code projects',
   },
 };
 

--- a/src/scripts/sync/generate-projects-diff-actions.ts
+++ b/src/scripts/sync/generate-projects-diff-actions.ts
@@ -25,10 +25,14 @@ export function generateProjectDiffActions(
 
   // any files in Snyk, not found in the repo should have the
   // related project deactivated
-  for (const project of snykMonitoredProjects.filter(
-    (p) => p.status !== 'inactive',
+  for (const project of getSupportedProjectsToDeactivate(
+    snykMonitoredProjects,
   )) {
-    if (!repoManifests.includes(project.name.split(':')[1])) {
+    const targetFile = project.name.split(':')[1];
+    if (!targetFile) {
+      continue;
+    }
+    if (!repoManifests.includes(targetFile)) {
       if (manifestTypes.includes(project.type)) {
         deactivate.push(project);
       }
@@ -39,4 +43,13 @@ export function generateProjectDiffActions(
     import: filesToImport,
     deactivate,
   };
+}
+
+// should return only projects that reference a manifest file in their name
+function getSupportedProjectsToDeactivate(
+  projects: SnykProject[],
+): SnykProject[] {
+  return projects
+    .filter((p) => p.status !== 'inactive')
+    .filter((p) => p.type !== 'sast');
 }

--- a/test/scripts/sync/generate-projects-diff-actions.spec.ts
+++ b/test/scripts/sync/generate-projects-diff-actions.spec.ts
@@ -63,6 +63,15 @@ describe('generateProjectDiffActions', () => {
         branch: 'master',
         status: 'active',
       },
+      {
+        name: 'snyk/goof:Code Analysis',
+        id: 'af137b96-6966-46c1-826b-2e79ac49bbxx',
+        created: '2018-10-29T09:50:54.014Z',
+        origin: 'github',
+        type: 'sast',
+        branch: 'master',
+        status: 'active',
+      },
     ];
     // Act
     const res = await generateProjectDiffActions(['package.json'], projects);
@@ -123,6 +132,15 @@ describe('generateProjectDiffActions', () => {
         created: '2018-10-29T09:50:54.014Z',
         origin: 'github',
         type: 'dockerfile',
+        branch: 'master',
+        status: 'active',
+      },
+      {
+        name: 'snyk/goof:Code Analysis',
+        id: 'af137b96-6966-46c1-826b-2e79ac49bbxx',
+        created: '2018-10-29T09:50:54.014Z',
+        origin: 'github',
+        type: 'sast',
         branch: 'master',
         status: 'active',
       },

--- a/test/system/sync.test.ts
+++ b/test/system/sync.test.ts
@@ -44,10 +44,11 @@ describe('`snyk-api-import sync <...>`', () => {
                [required] [choices: \\"github\\", \\"github-enterprise\\"] [default: \\"github\\"]
         --dryRun       Dry run option. Will create a log file listing the potential
                        updates                                        [default: false]
-        --snykProduct  List of Snyk Products to consider when syncing an SCM repo.
-                       Monitored Snyk Code repos are automatically synced already, if
-                       Snyk Code is enabled any new repo imports will include Snyk
-                       Code projects
+        --snykProduct  List of Snyk Products to consider when syncing an SCM repo for
+                       deleting projects & importing new ones (default branch will be
+                       updated for all projects in a target). Monitored Snyk Code
+                       repos are automatically synced already, if Snyk Code is enabled
+                       any new repo imports will bring in Snyk Code projects
                  [choices: \\"container\\", \\"open-source\\", \\"iac\\"] [default: \\"open-source\\"]
       "
       `);
@@ -170,7 +171,7 @@ describe('`snyk-api-import sync <...>`', () => {
         expect(stdout).toMatch(
           'Done syncing targets for source github-enterprise',
         );
-        expect(stdout).toMatch('Processed 3 targets (0 failed)');
+        expect(stdout).toMatch('Processed 4 targets (0 failed)');
         expect(stdout).toMatch('Updated 2 projects');
         const file = fs.readFileSync(updatedLog, 'utf8');
 


### PR DESCRIPTION
… out

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Adding extra checks to ensure Snyk Code projects can't be deactivated via sync command