### PR TITLE
Fix: exclude shared Gitlab projects but keep in the current group

### DIFF
--- a/src/lib/source-handlers/gitlab/list-repos.ts
+++ b/src/lib/source-handlers/gitlab/list-repos.ts
@@ -29,6 +29,8 @@ export async function fetchGitlabReposForPage(
   )) as gitBeakerTypes.Types.ProjectExtendedSchema[];
   const hasNextPage = projects.length ? true : false;
 
+  debug(`Found ${projects.length} projects in ${groupName}`);
+
   for (const project of projects) {
     const {
       archived,
@@ -38,11 +40,15 @@ export async function fetchGitlabReposForPage(
       path_with_namespace,
       id,
     } = project;
+
     if (
       archived ||
       !default_branch ||
       (shared_with_groups && shared_with_groups.length > 0)
     ) {
+      debug(
+        `Skipping project as it is either archived, has no default branch, shared with groups`,
+      );
       continue;
     }
 

--- a/src/lib/source-handlers/gitlab/list-repos.ts
+++ b/src/lib/source-handlers/gitlab/list-repos.ts
@@ -18,36 +18,38 @@ export async function fetchGitlabReposForPage(
   hasNextPage: boolean;
 }> {
   const repoData: GitlabRepoData[] = [];
-  const params = {
+  const params: gitBeakerTypes.Types.BaseRequestOptions = {
     // eslint-disable-next-line @typescript-eslint/camelcase
     perPage,
     page: pageNumber,
+    with_shared: false,
   };
+
   const projects = (await client.Groups.projects(
     groupName,
     params,
   )) as gitBeakerTypes.Types.ProjectExtendedSchema[];
-  const hasNextPage = projects.length ? true : false;
-
+  const hasNextPage = projects.length < perPage ? false : true;
   debug(`Found ${projects.length} projects in ${groupName}`);
 
   for (const project of projects) {
     const {
       archived,
-      shared_with_groups,
+      namespace,
       default_branch,
       forked_from_project,
       path_with_namespace,
       id,
     } = project;
-
-    if (
-      archived ||
-      !default_branch ||
-      (shared_with_groups && shared_with_groups.length > 0)
-    ) {
+    if (groupName !== namespace.name) {
       debug(
-        `Skipping project as it is either archived, has no default branch, shared with groups`,
+        `Skipping project ${project.name_with_namespace} as it belong to another group`,
+      );
+      continue;
+    }
+    if (archived || !default_branch) {
+      debug(
+        `Skipping project ${project.name_with_namespace} as it is either archived or has no default branch`,
       );
       continue;
     }

--- a/test/lib/source-handlers/gitlab/list-repos.test.ts
+++ b/test/lib/source-handlers/gitlab/list-repos.test.ts
@@ -22,8 +22,20 @@ describe('listGitlabRepos', () => {
       branch: expect.any(String),
       fork: expect.any(Boolean),
     });
-    for (let i = 0; i < repos.length; i++) {
-      expect(repos[i].name).not.toContain('shared-with-group');
-    }
+    expect(
+      repos.filter((r) => r.name === 'snyk-fixtures/shared-with-group'),
+    ).toHaveLength(1);
+  });
+  it('list repos (Gitlab Custom URL) excludes a shared project', async () => {
+    const GITLAB_BASE_URL = process.env.TEST_GITLAB_BASE_URL;
+    process.env.GITLAB_TOKEN = process.env.TEST_GITLAB_TOKEN;
+    // shared-with-group project is shared with group snyk-test
+    const gitlabGroupName = 'snyk-test';
+
+    const repos = await listGitlabRepos(gitlabGroupName, GITLAB_BASE_URL);
+    expect(
+      repos.filter((r) => r.name === 'snyk-fixtures/shared-with-group'),
+    ).toEqual([]);
+    expect(repos.length === 0).toBeTruthy();
   });
 });


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Exclude shared Gitlab projects but don;t exclude valid owned projects that are shared with other groups. Currently all projects that were shared were skipped which is a 🐛 