### PR TITLE
test: read log files after exit

### DIFF
--- a/test/system/orgs:create.test.ts
+++ b/test/system/orgs:create.test.ts
@@ -105,15 +105,15 @@ Options:
           'All requested organizations failed to be created. Review the errors in',
         );
         expect(stdout).toEqual('');
-        const file = fs.readFileSync(
-          path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`),
-          'utf8',
-        );
-        expect(file).toContain('Failed to create org');
-        deleteFiles([path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`)]);
       },
     ).on('exit', (code) => {
       expect(code).toEqual(1);
+      const file = fs.readFileSync(
+        path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`),
+        'utf8',
+      );
+      expect(file).toContain('Failed to create org');
+      deleteFiles([path.resolve(logPath, `abc.${FAILED_ORG_LOG_NAME}`)]);
       done();
     });
   }, 40000);
@@ -144,17 +144,17 @@ Options:
           'All requested organizations failed to be created. Review the errors in',
         );
         expect(stdout).toEqual('');
-        const file = fs.readFileSync(
-          path.resolve(logPath, `${GROUP_ID}.${FAILED_ORG_LOG_NAME}`),
-          'utf8',
-        );
-        expect(file).toContain('Refusing to create a duplicate organization');
-        deleteFiles([
-          path.resolve(logPath, `${GROUP_ID}.${FAILED_ORG_LOG_NAME}`),
-        ]);
       },
     ).on('exit', (code) => {
       expect(code).toEqual(1);
+      const file = fs.readFileSync(
+        path.resolve(logPath, `${GROUP_ID}.${FAILED_ORG_LOG_NAME}`),
+        'utf8',
+      );
+      expect(file).toContain('Refusing to create a duplicate organization');
+      deleteFiles([
+        path.resolve(logPath, `${GROUP_ID}.${FAILED_ORG_LOG_NAME}`),
+      ]);
       done();
     });
   }, 40000);

--- a/test/system/sync.test.ts
+++ b/test/system/sync.test.ts
@@ -173,17 +173,17 @@ describe('`snyk-api-import sync <...>`', () => {
         );
         expect(stdout).toMatch('Processed 3 targets (0 failed)');
         expect(stdout).toMatch('Updated 2 projects');
-        const file = fs.readFileSync(updatedLog, 'utf8');
-
-        // 1 project deactivated
-        expect(file).toMatch('"Snyk project \\"deactivate\\" update completed');
-        // another project has branch updated
-        expect(file).toMatch('"from":"main","to":"master"');
-
-        deleteFiles([updatedLog]);
       },
     ).on('exit', (code) => {
       expect(code).toEqual(0);
+      const file = fs.readFileSync(updatedLog, 'utf8');
+
+      // 1 project deactivated
+      expect(file).toMatch('"Snyk project \\"deactivate\\" update completed');
+      // another project has branch updated
+      expect(file).toMatch('"from":"main","to":"master"');
+
+      deleteFiles([updatedLog]);
       done();
     });
   }, 100000);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Read the test files a little after command stops