### PR TITLE
feat: bulk import target file batches

### DIFF
--- a/src/lib/api/poll-import/index.ts
+++ b/src/lib/api/poll-import/index.ts
@@ -78,7 +78,7 @@ export async function pollImportUrl(
 export async function pollImportUrls(
   requestManager: requestsManager,
   locationUrls: string[],
-): Promise<{ projects: Project[] }> {
+): Promise<{ projects: Project[]; failed: FailedProject[] }> {
   if (!locationUrls) {
     throw new Error(
       'Missing required parameters. Please ensure you have provided: locationUrls.',
@@ -130,5 +130,5 @@ export async function pollImportUrls(
 
   await logFailedProjects(allFailedProjects);
 
-  return { projects: projectsArray };
+  return { projects: projectsArray, failed: allFailedProjects };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -251,3 +251,9 @@ export type SyncTargetsConfig = {
   manifestTypes?: string[];
   exclusionGlobs?: string[];
 };
+
+export enum ProjectUpdateType {
+  BRANCH = 'branch',
+  DEACTIVATE = 'deactivate',
+  IMPORT = 'import',
+}

--- a/src/loggers/log-failed-projects.ts
+++ b/src/loggers/log-failed-projects.ts
@@ -9,6 +9,7 @@ const debug = debugLib('snyk:import-projects-script');
 
 export interface FailedProject extends Project {
   locationUrl: string;
+  userMessage?: string;
 }
 
 export async function logFailedProjects(

--- a/src/scripts/sync/import-target.ts
+++ b/src/scripts/sync/import-target.ts
@@ -2,11 +2,13 @@ import type { requestsManager } from 'snyk-request-manager';
 import * as debugLib from 'debug';
 import { defaultExclusionGlobs } from '../../common';
 import { importTarget, listIntegrations, pollImportUrls } from '../../lib';
+
 import type {
   Project,
-  SupportedIntegrationTypesUpdateProject,
   Target,
+  SupportedIntegrationTypesUpdateProject,
 } from '../../lib/types';
+import type { FailedProject } from '../../loggers/log-failed-projects';
 
 const debug = debugLib('snyk:import-single-target');
 
@@ -18,7 +20,7 @@ export async function importSingleTarget(
   filesToImport: string[] = [],
   excludeFolders?: string,
   loggingPath?: string,
-): Promise<{ projects: Project[] }> {
+): Promise<{ projects: Project[]; failed: FailedProject[] }> {
   const integrationsData = await listIntegrations(requestManager, orgId);
   const integrationId = integrationsData[integrationType];
   const files = filesToImport.map((f) => ({ path: f }));


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Unused / not exposed yet functionality to bulk import files detected in a repo in batches > poll to completion > next batch. This will ensure support for large monorepos where thousands of files may need to be imported which can fail if they are all processed at once due to hitting rate limits.