### PR TITLE
refactor: use target data not possibly empty projects data

### DIFF
--- a/test/scripts/sync/sync-org-projects.test.ts
+++ b/test/scripts/sync/sync-org-projects.test.ts
@@ -747,7 +747,6 @@ describe('updateTargets', () => {
 
       expect(githubSpy).toBeCalledWith(
         {
-          branch: 'master',
           name: 'monorepo',
           owner: 'snyk',
         },


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Use targets data to create the target info needed to call Github APIs in case we have no projects in this target in Snyk yet