### PR TITLE
fix: include more Gitlab projects that are dropped by a bad shared check

### DIFF
--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -32,7 +32,7 @@ This is an opinionated util and will assume every organization in Github.com / G
   --sourceOrgPublicId  Public id of the organization in Snyk that
                        can be used as a template to copy all
                        supported organization settings.
-  --skipEmptyOrgs      Skip organizations that have no targets. 
+  --skipEmptyOrgs      Skip organizations that have no targets.
                        (e.g. Github Organizations that have no repos)
 ```
 ## Github.com / Github Enterprise
@@ -50,7 +50,7 @@ This will create the organization data in a file `group-<snyk_group_id>-github-<
  - **Gitlab:** `snyk-api-import orgs:data --source=gitlab --groupId=<snyk_group_id>`
  - **Hosted Gitlab:** `snyk-api-import orgs:data --source=gitlab --groupId=<snyk_group_id> -- sourceUrl=https://gitlab.custom.com`
 
-This will create the organization data in a file `group-<snyk_group_id>-gitlab-orgs.json`
+This will create the organization data in a file `group-<snyk_group_id>-gitlab-orgs.json`. Both groups & sub-groups will be [listed](https://docs.gitlab.com/ee/api/groups.html) and then these will become Organizations in Snyk.
 
 
 ## Bitbucket Server

--- a/src/lib/source-handlers/gitlab/list-repos.ts
+++ b/src/lib/source-handlers/gitlab/list-repos.ts
@@ -41,7 +41,7 @@ export async function fetchGitlabReposForPage(
       path_with_namespace,
       id,
     } = project;
-    if (groupName !== namespace.name) {
+    if (groupName !== namespace.full_path) {
       debug(
         `Skipping project ${project.name_with_namespace} as it belong to another group`,
       );

--- a/test/lib/source-handlers/gitlab/list-repos.test.ts
+++ b/test/lib/source-handlers/gitlab/list-repos.test.ts
@@ -23,19 +23,27 @@ describe('listGitlabRepos', () => {
       fork: expect.any(Boolean),
     });
     expect(
-      repos.filter((r) => r.name === 'snyk-fixtures/shared-with-group'),
+      repos.filter((r) => r.name === `${GITLAB_ORG_NAME}/shared-with-group`),
     ).toHaveLength(1);
   });
   it('list repos (Gitlab Custom URL) excludes a shared project', async () => {
     const GITLAB_BASE_URL = process.env.TEST_GITLAB_BASE_URL;
+    const GITLAB_ORG_NAME = process.env.TEST_GITLAB_ORG_NAME;
     process.env.GITLAB_TOKEN = process.env.TEST_GITLAB_TOKEN;
     // shared-with-group project is shared with group snyk-test
     const gitlabGroupName = 'snyk-test';
-
     const repos = await listGitlabRepos(gitlabGroupName, GITLAB_BASE_URL);
     expect(
-      repos.filter((r) => r.name === 'snyk-fixtures/shared-with-group'),
+      repos.filter((r) => r.name === `${GITLAB_ORG_NAME}/shared-with-group`),
     ).toEqual([]);
-    expect(repos.length === 0).toBeTruthy();
+    expect(repos.length > 0).toBeTruthy();
+  });
+
+  it('list repos for a sub-group', async () => {
+    const GITLAB_BASE_URL = process.env.TEST_GITLAB_BASE_URL;
+    process.env.GITLAB_TOKEN = process.env.TEST_GITLAB_TOKEN;
+    const gitlabGroupName = 'snyk-fixtures/example-sub-group';
+    const repos = await listGitlabRepos(gitlabGroupName, GITLAB_BASE_URL);
+    expect(repos.length > 0).toBeTruthy();
   });
 });

--- a/test/system/orgs:data/gitlab.test.ts
+++ b/test/system/orgs:data/gitlab.test.ts
@@ -26,7 +26,7 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
         expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout).toMatch(
-          'Found 14 group(s). Written the data to file: group-hello-gitlab-orgs.json',
+          'Found 15 group(s). Written the data to file: group-hello-gitlab-orgs.json',
         );
         deleteFiles([
           path.resolve(__dirname, `group-${groupId}-gitlab-orgs.json`),


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Some projects were being discarded due to several incorrect shared with group checks. Adding a test to ensure we can list projects from a sub-group & can see the group. 