### PR TITLE
refactor: fetch integration id via API less

### DIFF
--- a/src/scripts/sync/import-target.ts
+++ b/src/scripts/sync/import-target.ts
@@ -1,13 +1,9 @@
 import type { requestsManager } from 'snyk-request-manager';
 import * as debugLib from 'debug';
 import { defaultExclusionGlobs } from '../../common';
-import { importTarget, listIntegrations, pollImportUrls } from '../../lib';
+import { importTarget, pollImportUrls } from '../../lib';
 
-import type {
-  Project,
-  Target,
-  SupportedIntegrationTypesUpdateProject,
-} from '../../lib/types';
+import type { Project, Target } from '../../lib/types';
 import type { FailedProject } from '../../loggers/log-failed-projects';
 
 const debug = debugLib('snyk:import-single-target');
@@ -15,14 +11,12 @@ const debug = debugLib('snyk:import-single-target');
 export async function importSingleTarget(
   requestManager: requestsManager,
   orgId: string,
-  integrationType: SupportedIntegrationTypesUpdateProject,
+  integrationId: string,
   target: Target,
   filesToImport: string[] = [],
   excludeFolders?: string,
   loggingPath?: string,
 ): Promise<{ projects: Project[]; failed: FailedProject[] }> {
-  const integrationsData = await listIntegrations(requestManager, orgId);
-  const integrationId = integrationsData[integrationType];
   const files = filesToImport.map((f) => ({ path: f }));
   const { pollingUrl } = await importTarget(
     requestManager,

--- a/src/scripts/sync/sync-projects-per-target.ts
+++ b/src/scripts/sync/sync-projects-per-target.ts
@@ -285,7 +285,7 @@ export async function bulkImportTargetFiles(
   requestManager: requestsManager,
   orgId: string,
   files: string[] = [],
-  integrationType: SupportedIntegrationTypesUpdateProject,
+  integrationId: string,
   target: Target,
   dryRun = false,
   concurrentFilesImport = 30,
@@ -322,7 +322,7 @@ export async function bulkImportTargetFiles(
     const { projects, failed: failedProjects } = await importSingleTarget(
       requestManager,
       orgId,
-      integrationType,
+      integrationId,
       target,
       batch,
     );

--- a/test/scripts/sync/import-target.spec.ts
+++ b/test/scripts/sync/import-target.spec.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import { requestsManager } from 'snyk-request-manager';
 import { importSingleTarget } from '../../../src/scripts/sync/import-target';
-import { SupportedIntegrationTypesUpdateProject } from '../../../src/lib/types';
 import type { Project } from '../../../src/lib/types';
 import { deleteFiles } from '../../delete-files';
 import { deleteTestProjects } from '../../delete-test-projects';
@@ -9,6 +8,7 @@ import { generateLogsPaths } from '../../generate-log-file-names';
 
 const ORG_ID = process.env.TEST_ORG_ID as string;
 const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
+const GHE_INTEGRATION_ID = process.env.GHE_INTEGRATION_ID as string;
 
 jest.unmock('snyk-request-manager');
 jest.requireActual('snyk-request-manager');
@@ -43,7 +43,7 @@ describe('Import projects script', () => {
     const { projects } = await importSingleTarget(
       requestManager,
       ORG_ID,
-      SupportedIntegrationTypesUpdateProject.GHE,
+      GHE_INTEGRATION_ID,
       target,
     );
     expect(projects).not.toBe([]);
@@ -72,7 +72,7 @@ describe('Import projects script', () => {
     const { projects } = await importSingleTarget(
       requestManager,
       ORG_ID,
-      SupportedIntegrationTypesUpdateProject.GHE,
+      GHE_INTEGRATION_ID,
       target,
       undefined,
       'ruby-2.5.3-exactly',

--- a/test/scripts/sync/sync-org-projects.test.ts
+++ b/test/scripts/sync/sync-org-projects.test.ts
@@ -1328,6 +1328,7 @@ describe('bulkImportTargetFiles', () => {
   let logs: string[];
   const OLD_ENV = process.env;
   process.env.SNYK_TOKEN = process.env.SNYK_TOKEN_TEST;
+  const GHE_INTEGRATION_ID = process.env.GHE_INTEGRATION_ID as string;
   const ORG_ID = 'af137b96-6966-46c1-826b-2e79ac49bbxx';
   let importSingleTargetSpy: jest.SpyInstance;
 
@@ -1373,7 +1374,7 @@ describe('bulkImportTargetFiles', () => {
       requestManager,
       ORG_ID,
       ['ruby-2.5.3-exactly/Gemfile'],
-      SupportedIntegrationTypesUpdateProject.GHE,
+      GHE_INTEGRATION_ID,
       target,
     );
     expect(importSingleTargetSpy).toHaveBeenCalledTimes(1);
@@ -1451,7 +1452,7 @@ describe('bulkImportTargetFiles', () => {
       requestManager,
       ORG_ID,
       projects.map((p) => p.targetFile!),
-      SupportedIntegrationTypesUpdateProject.GHE,
+      GHE_INTEGRATION_ID,
       target,
       false,
       2,
@@ -1532,7 +1533,7 @@ describe('bulkImportTargetFiles', () => {
       requestManager,
       ORG_ID,
       projects.map((p) => p.targetFile!),
-      SupportedIntegrationTypesUpdateProject.GHE,
+      GHE_INTEGRATION_ID,
       target,
       true,
       2,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Refactor so the Integration ID can begrabbed once per org and not once per batch or target to reduce Snyk API calls