### PR TITLE
chore: only post slack notifications on nightly test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             - slack/notify:
                 channel: C0137E8F72A
                 color: '#42e2f4'
-                message: Starting snyk-api-import build-test-monitor job
+                message: snyk-api-import build-test-monitor nightly job
             - checkout
             - run: npm install
             - run: npm test
@@ -22,10 +22,6 @@ jobs:
         docker:
             - image: circleci/node:14
         steps:
-            - slack/notify:
-                channel: C0137E8F72A
-                color: '#42e2f4'
-                message: Starting snyk-api-import build-test job
             - checkout
             - run: npm install
             - run: npm test

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -11,7 +11,7 @@ import { generateLogsPaths } from '../generate-log-file-names';
 import { deleteFiles } from '../delete-files';
 
 const ORG_ID = process.env.TEST_ORG_ID as string;
-const INTEGRATION_ID = process.env.TEST_INTEGRATION_ID as string;
+const INTEGRATION_ID = process.env.GHE_INTEGRATION_ID as string;
 const SNYK_API_TEST = process.env.SNYK_API_TEST as string;
 
 jest.unmock('snyk-request-manager');


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Update slack orb config to only post notifications on nightly jobs