### PR TITLE
chore: mirroring Github & GHE with sync command

### DIFF
--- a/docs/mirror-github.md
+++ b/docs/mirror-github.md
@@ -20,6 +20,11 @@ Once initial import is complete you may want to periodically check for new repos
 2. Generate organization data in Snyk and skip any that do not have any repos via `--skipEmptyOrg` `snyk-api-import orgs:data --source=github --groupId=<snyk_group_id> --skipEmptyOrg` [Full instructions](./orgs.md)
 3. Create organizations in Snyk and this time skip any that have been created already with `--noDuplicateNames` parameter `snyk-api-import orgs:create --file=orgs.json --noDuplicateNames` [Full instructions](./orgs.md) will create a `snyk-created-orgs.json` file with Snyk organization ids and integration ids that are needed for import.
 4. Generate import data `snyk-api-import import:data --orgsData=snyk-created-orgs.json --source=github` [Full instructions](./import-data.md)
-5. Optional. Generate the previously imported log to skip all previously imported repos a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
+5. Generate the previously imported log to skip all previously imported repos in a Group (see full [documentation](./import.md#to-skip-all-previously-imported-targets)):
 `snyk-api-import-macos list:imported --integrationType=<integration-type> --groupId=<snyk_group_id>`
 6. Run import `DEBUG=*snyk* snyk-api-import import`[Full instructions](./import.md)
+
+## Syncing previously imported repos
+For repos already monitored in Snyk use the `sync` command to detect changes and update projects in Snyk.
+1. Get a list of Snyk Organizations in the Group by listing all organizations a group admin belongs to via [Snyk Organizations API](https://snyk.docs.apiary.io/#reference/groups/list-all-organizations-in-a-group/list-all-organizations-in-a-group)
+2. For every public Organization ID, run `sync` command [Full instructions](./sync.md)


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Mirror docs updated to share how sync can be used to avoid re-importing repos