### PR TITLE
fix: [SMA-145] Easing failure of rmdirSync

### DIFF
--- a/src/scripts/sync/clone-and-analyze.ts
+++ b/src/scripts/sync/clone-and-analyze.ts
@@ -62,7 +62,11 @@ export async function cloneAndAnalyze(
     )}`,
   );
 
-  fs.rmdirSync(repoPath, { recursive: true });
+  try {
+    fs.rmdirSync(repoPath, { recursive: true });
+  } catch (error) {
+    debug(`Failed to delete ${repoPath}. Error was ${error}.`);
+  }
 
   return generateProjectDiffActions(
     relativeFileNames,


### PR DESCRIPTION
### What this does

We've detected an incident where a customer's flow was broken due to a filesystem error when trying to delete a non-empty folder. Shouldn't really be possible as I see it, but it did happen.

This PR eases the logic to not break the flow and only render a warning in such cases.