### PR TITLE
test: Fix failing test for bitbucket orgs:data

### DIFF
--- a/test/system/orgs:data/bitbucket.test.ts
+++ b/test/system/orgs:data/bitbucket.test.ts
@@ -26,7 +26,7 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
         expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout).toMatch(
-          'Found 2 project(s). Written the data to file: group-hello-bitbucket-server-orgs.json',
+          'Found 3 project(s). Written the data to file: group-hello-bitbucket-server-orgs.json',
         );
         deleteFiles([
           path.resolve(


### PR DESCRIPTION
### What this does

Fixes a failing test for Bitbucket after a new repo was added to the test account.
