### PR TITLE
chore: update test assertions to match new token

### DIFF
--- a/test/scripts/generate-targets-data.test.ts
+++ b/test/scripts/generate-targets-data.test.ts
@@ -147,7 +147,9 @@ describe('generateTargetsImportDataFile Github script', () => {
     );
     expect(res.fileName).toEqual('github-import-targets.json');
     expect(res.targets.length > 0).toBeTruthy();
-    expect(_.uniqBy(res.targets, 'target.name')).toBeTruthy();
+    expect(
+      new Set(res.targets.map((t) => t.target.name)).size == res.targets.length,
+    ).toBeTruthy();
     expect(res.targets[0]).toEqual({
       target: {
         name: expect.any(String),

--- a/test/system/orgs:data/github.test.ts
+++ b/test/system/orgs:data/github.test.ts
@@ -26,7 +26,7 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
         expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout).toMatch(
-          'Found 9 organization(s). Written the data to file: group-hello-github-com-orgs.json',
+          'Found 4 organization(s). Written the data to file: group-hello-github-com-orgs.json',
         );
         deleteFiles([
           path.resolve(__dirname, `group-${groupId}-github-com-orgs.json`),


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Tweak test assertions since new token has less access