### PR TITLE
chore: drop usage of gh_token

### DIFF
--- a/test/system/orgs:data/generic.test.ts
+++ b/test/system/orgs:data/generic.test.ts
@@ -13,7 +13,7 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
       {
         env: {
           PATH: process.env.PATH,
-          GITHUB_TOKEN: process.env.GH_TOKEN,
+          GITHUB_TOKEN: process.env.GITHUB_TOKEN,
           SNYK_LOG_PATH: __dirname,
         },
       },

--- a/test/system/orgs:data/github.test.ts
+++ b/test/system/orgs:data/github.test.ts
@@ -15,7 +15,7 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
       {
         env: {
           PATH: process.env.PATH,
-          GITHUB_TOKEN: process.env.GH_TOKEN,
+          GITHUB_TOKEN: process.env.GITHUB_TOKEN,
           SNYK_LOG_PATH: __dirname,
         },
       },
@@ -26,7 +26,7 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
         expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout).toMatch(
-          'Found 4 organization(s). Written the data to file: group-hello-github-com-orgs.json',
+          'Found 2 organization(s). Written the data to file: group-hello-github-com-orgs.json',
         );
         deleteFiles([
           path.resolve(__dirname, `group-${groupId}-github-com-orgs.json`),


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Remove last remaining GH_TOKEN references