### PR TITLE
test: wait before reading log file

### DIFF
--- a/test/lib/source-handlers/gitlab/list-groups.test.ts
+++ b/test/lib/source-handlers/gitlab/list-groups.test.ts
@@ -17,5 +17,5 @@ describe('listGitlabGroups', () => {
       id: expect.any(Number),
       url: expect.any(String),
     });
-  });
+  }, 10000);
 });

--- a/test/lib/source-handlers/gitlab/list-repos.test.ts
+++ b/test/lib/source-handlers/gitlab/list-repos.test.ts
@@ -25,7 +25,7 @@ describe('listGitlabRepos', () => {
     expect(
       repos.filter((r) => r.name === `${GITLAB_ORG_NAME}/shared-with-group`),
     ).toHaveLength(1);
-  });
+  }, 10000);
   it('list repos (Gitlab Custom URL) excludes a shared project', async () => {
     const GITLAB_BASE_URL = process.env.TEST_GITLAB_BASE_URL;
     const GITLAB_ORG_NAME = process.env.TEST_GITLAB_ORG_NAME;
@@ -37,7 +37,7 @@ describe('listGitlabRepos', () => {
       repos.filter((r) => r.name === `${GITLAB_ORG_NAME}/shared-with-group`),
     ).toEqual([]);
     expect(repos.length > 0).toBeTruthy();
-  });
+  }, 10000);
 
   it('list repos for a sub-group', async () => {
     const GITLAB_BASE_URL = process.env.TEST_GITLAB_BASE_URL;
@@ -45,5 +45,5 @@ describe('listGitlabRepos', () => {
     const gitlabGroupName = 'snyk-fixtures/example-sub-group';
     const repos = await listGitlabRepos(gitlabGroupName, GITLAB_BASE_URL);
     expect(repos.length > 0).toBeTruthy();
-  });
+  }, 10000);
 });

--- a/test/scripts/import-projects.test.ts
+++ b/test/scripts/import-projects.test.ts
@@ -41,6 +41,8 @@ describe('Import projects script', () => {
       success: true,
       targetFile: expect.any(String),
     });
+    // give file a little time to be finished to be written
+    await new Promise((r) => setTimeout(r, 5000));
     const logFile = fs.readFileSync(logFiles.importLogPath, 'utf8');
     // Github project
     expect(logFile).toMatch(
@@ -63,6 +65,8 @@ describe('Import projects script', () => {
       success: true,
       targetFile: expect.any(String),
     });
+    // give file a little time to be finished to be written
+    await new Promise((r) => setTimeout(r, 5000));
     const logFile = fs.readFileSync(logFiles.importLogPath, 'utf8');
     // Gitlab project
     expect(logFile).toMatch(


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Small wait before reading log file that might take a bit longer to write