### PR TITLE
fix: remove infinite loop 422

### DIFF
--- a/src/lib/api/poll-import/index.ts
+++ b/src/lib/api/poll-import/index.ts
@@ -1,6 +1,6 @@
 import 'source-map-support/register';
 import * as url from 'url';
-import { requestsManager } from 'snyk-request-manager';
+import type { requestsManager } from 'snyk-request-manager';
 import * as sleep from 'sleep-promise';
 import * as debugLib from 'debug';
 import * as _ from 'lodash';
@@ -33,28 +33,25 @@ export async function pollImportUrl(
   }
   try {
     const { pathname = '' } = url.parse(locationUrl);
-    const res = await tryPolling(
-      requestManager,
-      (pathname as string).split('/api/v1/')[1],
-    );
+    const res = await requestManager.request({
+      verb: 'get',
+      url: (pathname as string).split('/api/v1/')[1],
+      body: JSON.stringify({}),
+    });
     const importStatus: PollImportResponse = res.data;
     const statusCode = res.statusCode || res.status;
 
-    if (!statusCode || ![422, 200].includes(statusCode)) {
+    if (!statusCode || statusCode !== 200) {
       throw new Error(
         'Expected a 200 response, instead received: ' +
           JSON.stringify({ data: res.data, status: statusCode }),
       );
     }
-    if (statusCode == 422) {
-      retryCount = 3;
-    }
     debug(`Import task status is "${importStatus.status}"`);
     if (
-      statusCode == 422 ||
-      (importStatus.status &&
-        importStatus.status !== 'complete' &&
-        retryCount > 0)
+      importStatus.status &&
+      importStatus.status !== 'complete' &&
+      retryCount > 0
     ) {
       await sleep(retryWaitTime);
       debug(`Will re-check import task in "${retryWaitTime} ms"`);
@@ -76,24 +73,6 @@ export async function pollImportUrl(
     } = new Error('Could not poll Url');
     err.innerError = error;
     throw err;
-  }
-}
-
-async function tryPolling(requestManager: requestsManager, pollingUrl: string) {
-  try {
-    const res = await requestManager.request({
-      verb: 'get',
-      url: pollingUrl,
-      body: JSON.stringify({}),
-    });
-
-    return res;
-  } catch (e) {
-    if (e.message?.response?.status == 422) {
-      return e.message?.response;
-    }
-
-    throw e;
   }
 }
 


### PR DESCRIPTION
### What this does

Removes part of the changes from [this PR](https://github.com/snyk-tech-services/snyk-api-import/commit/64722b9b7a690591ea516414a4d77328f23f167b) as they are no longer needed and they introduce an infinite loop.

The 422s were happening when the job was persisted in import service but not in registry yet. We made a change that whenever that happens, registry queries import service and if the job exists there, we don't send 422 anymore. As a result, we don't need the retry anymore.

