### PR TITLE
fix: bump node version to latest available 12

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,22 +9,22 @@
     {
       "//": "build the macos",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t mac-x64-12.9.0 -o snyk-api-import-macos"
+      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t mac-x64-12.18.2 -o snyk-api-import-macos"
     },
     {
       "//": "build the linux",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t linux-x64-12.9.0 -o snyk-api-import-linux"
+      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t linux-x64-12.16.2 -o snyk-api-import-linux"
     },
     {
       "//": "build the alpine",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t alpine-x64-12.9.0 -o snyk-api-import-alpine"
+      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t alpine-x64-12.9.1 -o snyk-api-import-alpine"
     },
     {
       "//": "build the windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t windows-x64-12.9.0 -o snyk-api-import-win.exe"
+      "cmd": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t windows-x64-12.18.2 -o snyk-api-import-win.exe"
     },
     {
       "//": "shasum all binaries",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "build-watch": "tsc -w",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "pkg-binaries-linux": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t linux-x64-12.9.0 -o snyk-api-import-linux",
-    "pkg-binaries": "npx nexe@3.3.7 dist/index.js -r './dist/**/*.js' -t mac-x64-12.9.0 -o snyk-api-import-macos"
+    "pkg-binaries-linux": "npx nexe@3.3.7 dist/index.js  -r './dist/**/*.js' -t linux-x64-12.16.2 -o snyk-api-import-linux",
+    "pkg-binaries": "npx nexe@3.3.7 dist/index.js -r './dist/**/*.js' -t mac-x64-12.18.2 -o snyk-api-import-macos"
   },
   "types": "./dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
Version 12.9.0 used previously had a bug that wouldn't delete folders recursively. This resulted in cloned repos not being deleted. Upgrading to the latest available v12 fixes the issue with the exception of alpine.

Nexe only supports alpine node 12.9.1 which does not have the fix yet. We will address that in a separate PR, for now unblocking other builds.
