### PR TITLE
fix: match project keys exactly in BBS search

### DIFF
--- a/src/lib/source-handlers/bitbucket-server/list-repos.ts
+++ b/src/lib/source-handlers/bitbucket-server/list-repos.ts
@@ -78,7 +78,9 @@ const getRepos = async (
   const { values, isLastPage, nextPageStart } = body;
   start = nextPageStart || -1;
   for (const repo of values) {
-    repos.push({ projectKey: repo.project.key, repoSlug: repo.name });
+    if (repo.project.key === projectKey) {
+      repos.push({ projectKey: repo.project.key, repoSlug: repo.name });
+    }
   }
   return { repos, isLastPage, start };
 };

--- a/test/system/fixtures/org-data/bitbucket-server-orgs.json
+++ b/test/system/fixtures/org-data/bitbucket-server-orgs.json
@@ -1,7 +1,7 @@
 {
   "orgData": [
     {
-      "name": "antoine-snyk-demo",
+      "name": "AN",
       "orgId": "<snyk_org_id>",
       "integrations": {
         "bitbucket-server": "<snyk_org_integration_id>"


### PR DESCRIPTION
The BBS search endpoint matches by prefix, returning repos hosted in e.g. `bla-1` when searching for just project `bla`. In some cases this results in two Snyk projects created for the same manifest in different orgs.

This PR adds a condition to double-check that repos aren't being added to the wrong org.

This could also be fixed by switching to another API endpoint but prefer not to make this investment as the project is in maintenance mode now.
