### PR TITLE
fix: check if project name matches when fetching repos

### DIFF
--- a/src/lib/source-handlers/bitbucket-server/project-is-empty.ts
+++ b/src/lib/source-handlers/bitbucket-server/project-is-empty.ts
@@ -2,7 +2,7 @@ import { getBitbucketServerToken } from './get-bitbucket-server-token';
 import { fetchAllRepos } from './list-repos';
 
 export async function bitbucketServerProjectIsEmpty(
-  projectKey: string,
+  projectName: string,
   sourceUrl?: string,
 ): Promise<boolean> {
   const bitbucketServerToken = getBitbucketServerToken();
@@ -13,7 +13,7 @@ export async function bitbucketServerProjectIsEmpty(
   }
   const repos = await fetchAllRepos(
     sourceUrl,
-    projectKey,
+    projectName,
     bitbucketServerToken,
   );
   if (!repos || repos.length === 0) {

--- a/test/system/fixtures/org-data/bitbucket-server-orgs.json
+++ b/test/system/fixtures/org-data/bitbucket-server-orgs.json
@@ -1,7 +1,7 @@
 {
   "orgData": [
     {
-      "name": "AN",
+      "name": "antoine-snyk-demo",
       "orgId": "<snyk_org_id>",
       "integrations": {
         "bitbucket-server": "<snyk_org_integration_id>"


### PR DESCRIPTION
Checks that the project name matches when listing repos for an org.

Renames variable from `projectKey` to `projectName` so that it's not confusing. The value is actually the name of the project in Bitbucket.
