### PR TITLE
fix: fix Bitbucket Server tests

### DIFF
--- a/test/system/fixtures/org-data/bitbucket-server-orgs.json
+++ b/test/system/fixtures/org-data/bitbucket-server-orgs.json
@@ -1,7 +1,7 @@
 {
   "orgData": [
     {
-      "name": "antoine-snyk-demo",
+      "name": "comet-qa",
       "orgId": "<snyk_org_id>",
       "integrations": {
         "bitbucket-server": "<snyk_org_integration_id>"

--- a/test/system/orgs:data/bitbucket.test.ts
+++ b/test/system/orgs:data/bitbucket.test.ts
@@ -26,7 +26,7 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
         expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout).toMatch(
-          'Found 3 project(s). Written the data to file: group-hello-bitbucket-server-orgs.json',
+          'Found 1 project(s). Written the data to file: group-hello-bitbucket-server-orgs.json',
         );
         deleteFiles([
           path.resolve(


### PR DESCRIPTION
### What this does

Bitbucket  Server tests were failing because the BBS was moved to the backoffice instance. 
This PR fixes the failing BBS tests.